### PR TITLE
关于关联式容器中set和map的insert的返回值

### DIFF
--- a/docs/lang/csl/associative-container.md
+++ b/docs/lang/csl/associative-container.md
@@ -86,7 +86,8 @@ map<string, int> mp;
 ```cpp
 map<string, int> mp = {{"Tom", 0}, {"Bob", "100"}, {"Alan", 100}};
 ```
-（注：在使用insert函数时将返回一个类型为`pair <iterator，bool>`的值，其中iterator是一个新元素的迭代器，而bool则是判断元素是否插入成功，由于`map`中的元素具有唯一性质，所以如果再`map`中若已有等效元素，则可能插入失败，返回false，反之则返回true，`set`中的insert也是如此）
+
+（注：在使用 insert 函数时将返回一个类型为 `pair <iterator，bool>` 的值，其中 iterator 是一个新元素的迭代器，而 bool 则是判断元素是否插入成功，由于 `map` 中的元素具有唯一性质，所以如果再 `map` 中若已有等效元素，则可能插入失败，返回 false，反之则返回 true， `set` 中的 insert 也是如此）
 
 ### 查找、修改元素
 

--- a/docs/lang/csl/associative-container.md
+++ b/docs/lang/csl/associative-container.md
@@ -87,7 +87,8 @@ map<string, int> mp;
 map<string, int> mp = {{"Tom", 0}, {"Bob", "100"}, {"Alan", 100}};
 ```
 
-（注：在使用 insert 函数时将返回一个类型为 `pair <iterator，bool>` 的值，其中 iterator 是一个新元素的迭代器，而 bool 则是判断元素是否插入成功，由于 `map` 中的元素具有唯一性质，所以如果再 `map` 中若已有等效元素，则可能插入失败，返回 false，反之则返回 true， `set` 中的 insert 也是如此）
+???+note "insert 函数的返回值"
+    insert 函数的返回值类型为 `pair<iterator, bool>`，其中 iterator 是一个指向所插入元素（或者是指向等于所插入值的原本就在容器中的元素）的迭代器，而 bool 则代表元素是否插入成功，由于 `map` 中的元素具有唯一性质，所以如果在 `map` 中若已有等值元素，则插入会失败，返回 false，若插入成功则返回 true；`set` 中的 insert 也是如此。
 
 ### 查找、修改元素
 

--- a/docs/lang/csl/associative-container.md
+++ b/docs/lang/csl/associative-container.md
@@ -86,6 +86,7 @@ map<string, int> mp;
 ```cpp
 map<string, int> mp = {{"Tom", 0}, {"Bob", "100"}, {"Alan", 100}};
 ```
+（注：在使用insert函数时将返回一个类型为`pair <iterator，bool>`的值，其中iterator是一个新元素的迭代器，而bool则是判断元素是否插入成功，由于`map`中的元素具有唯一性质，所以如果再`map`中若已有等效元素，则可能插入失败，返回false，反之则返回true，`set`中的insert也是如此）
 
 ### 查找、修改元素
 

--- a/docs/lang/csl/associative-container.md
+++ b/docs/lang/csl/associative-container.md
@@ -12,6 +12,9 @@
 -    `erase(first,last)` 删除迭代器在 $[first,last)$ 范围内的所有元素。
 -    `clear()` 清空 `set` 。
 
+???+note "insert 函数的返回值"
+    insert 函数的返回值类型为 `pair<iterator, bool>` ，其中 iterator 是一个指向所插入元素（或者是指向等于所插入值的原本就在容器中的元素）的迭代器，而 bool 则代表元素是否插入成功，由于 `map` 中的元素具有唯一性质，所以如果在 `map` 中若已有等值元素，则插入会失败，返回 false，若插入成功则返回 true； `map` 中的 insert 也是如此。
+
 ### 迭代器
 
  `set` 提供了以下几种迭代器：
@@ -86,9 +89,6 @@ map<string, int> mp;
 ```cpp
 map<string, int> mp = {{"Tom", 0}, {"Bob", "100"}, {"Alan", 100}};
 ```
-
-关于 insert 函数的返回值
-    insert 函数的返回值类型为 `pair<iterator, bool>` ，其中 iterator 是一个指向所插入元素（或者是指向等于所插入值的原本就在容器中的元素）的迭代器，而 bool 则代表元素是否插入成功，由于 `map` 中的元素具有唯一性质，所以如果在 `map` 中若已有等值元素，则插入会失败，返回 false，若插入成功则返回 true； `set` 中的 insert 也是如此。
 
 ### 查找、修改元素
 

--- a/docs/lang/csl/associative-container.md
+++ b/docs/lang/csl/associative-container.md
@@ -13,7 +13,7 @@
 -    `clear()` 清空 `set` 。
 
 ???+note "insert 函数的返回值"
-    insert 函数的返回值类型为 `pair<iterator, bool>` ，其中 iterator 是一个指向所插入元素（或者是指向等于所插入值的原本就在容器中的元素）的迭代器，而 bool 则代表元素是否插入成功，由于 `set` 中的元素具有唯一性质，所以如果在 `set` 中若已有等值元素，则插入会失败，返回 false，若插入成功则返回 true； `map` 中的 insert 也是如此。
+    insert 函数的返回值类型为 `pair<iterator, bool>` ，其中 iterator 是一个指向所插入元素（或者是指向等于所插入值的原本就在容器中的元素）的迭代器，而 bool 则代表元素是否插入成功，由于 `set` 中的元素具有唯一性质，所以如果在 `set` 中已有等值元素，则插入会失败，返回 false，否则插入成功，返回 true； `map` 中的 insert 也是如此。
 
 ### 迭代器
 

--- a/docs/lang/csl/associative-container.md
+++ b/docs/lang/csl/associative-container.md
@@ -87,7 +87,7 @@ map<string, int> mp;
 map<string, int> mp = {{"Tom", 0}, {"Bob", "100"}, {"Alan", 100}};
 ```
 
-???+note "insert 函数的返回值"
+关于 insert 函数的返回值
     insert 函数的返回值类型为 `pair<iterator, bool>` ，其中 iterator 是一个指向所插入元素（或者是指向等于所插入值的原本就在容器中的元素）的迭代器，而 bool 则代表元素是否插入成功，由于 `map` 中的元素具有唯一性质，所以如果在 `map` 中若已有等值元素，则插入会失败，返回 false，若插入成功则返回 true； `set` 中的 insert 也是如此。
 
 ### 查找、修改元素

--- a/docs/lang/csl/associative-container.md
+++ b/docs/lang/csl/associative-container.md
@@ -88,7 +88,7 @@ map<string, int> mp = {{"Tom", 0}, {"Bob", "100"}, {"Alan", 100}};
 ```
 
 ???+note "insert 函数的返回值"
-    insert 函数的返回值类型为 `pair<iterator, bool>`，其中 iterator 是一个指向所插入元素（或者是指向等于所插入值的原本就在容器中的元素）的迭代器，而 bool 则代表元素是否插入成功，由于 `map` 中的元素具有唯一性质，所以如果在 `map` 中若已有等值元素，则插入会失败，返回 false，若插入成功则返回 true；`set` 中的 insert 也是如此。
+    insert 函数的返回值类型为 `pair<iterator, bool>` ，其中 iterator 是一个指向所插入元素（或者是指向等于所插入值的原本就在容器中的元素）的迭代器，而 bool 则代表元素是否插入成功，由于 `map` 中的元素具有唯一性质，所以如果在 `map` 中若已有等值元素，则插入会失败，返回 false，若插入成功则返回 true； `set` 中的 insert 也是如此。
 
 ### 查找、修改元素
 

--- a/docs/lang/csl/associative-container.md
+++ b/docs/lang/csl/associative-container.md
@@ -13,7 +13,7 @@
 -    `clear()` 清空 `set` 。
 
 ???+note "insert 函数的返回值"
-    insert 函数的返回值类型为 `pair<iterator, bool>` ，其中 iterator 是一个指向所插入元素（或者是指向等于所插入值的原本就在容器中的元素）的迭代器，而 bool 则代表元素是否插入成功，由于 `map` 中的元素具有唯一性质，所以如果在 `map` 中若已有等值元素，则插入会失败，返回 false，若插入成功则返回 true； `map` 中的 insert 也是如此。
+    insert 函数的返回值类型为 `pair<iterator, bool>` ，其中 iterator 是一个指向所插入元素（或者是指向等于所插入值的原本就在容器中的元素）的迭代器，而 bool 则代表元素是否插入成功，由于 `set` 中的元素具有唯一性质，所以如果在 `set` 中若已有等值元素，则插入会失败，返回 false，若插入成功则返回 true； `map` 中的 insert 也是如此。
 
 ### 迭代器
 


### PR DESCRIPTION
insert的返回值对于Oier们来讲具有很好的便利性，在BZOJ 2203A New Operating System一题中有很好的体现，或许有其他的写法，但是直接使用insert的返回值会更加的高效，使代码更简洁，有加入的必要
<!--
首先，十分感谢你花时间来给 OI Wiki 开一个 Pull Request，下面是一些你可能需要知道的信息：

- 请在 commit 的时候写比较有意义的 commit message
- 请给 PR 起比较有意义的标题。
- 如果您的 PR 可以解决某个现有的 issue，请在这个文本框的开头部分写上 fix + issue 编号。 如：fix #1622
- 关于文档内容的基本格式和基本内容规范，可以查阅 [如何参与](https://oi-wiki.org/intro/htc)。
- 请确保勾选了下方允许维护者修改的候选框（lint bot 需要在 PR 环节修正格式）

**如果有需要额外注明的内容，请写在这个文本框的开头部分 :smile: 谢谢～**
-->

**审核的同学** 请着重关注以下四方面：

1. 注意有没有 typo
2. 不论你是否熟悉相关知识，都请以初学者的角度把这个 PR 的内容阅读一遍，跟着作者的思路走，然后谈谈你的感受
3. 如果你熟悉相关知识，请按照自己的理解评估这个 PR 的内容是否合适
4. 请**尽量**保持跟进直到它被 merge 或 close
