### PR TITLE
修复了平面计算几何的一个错误

### DIFF
--- a/docs/geometry/2d.md
+++ b/docs/geometry/2d.md
@@ -210,7 +210,7 @@ $$
 将多边形上的点逆时针标记为 $p_1,p_2,\cdots ,p_n$ ，再任选一个辅助点 $O$ ，记向量 $\mathbf v_i=p_i-O$ ，那么这个多边形面积 $S$ 可以表示为：
 
 $$
-S=\frac{1}{2}\sum_{i=1}^n |\mathbf v_i\times \mathbf v_{i\bmod n+1}|
+S=\frac{1}{2}|\sum_{i=1}^n \mathbf v_i\times \mathbf v_{i\bmod n+1}|
 $$
 
 ### 圆与直线相关


### PR DESCRIPTION
多边形面积<del>距离</del>应该是向量叉乘和的模而不是向量叉乘模的和。


