### PR TITLE
【0-1 BFS】移除不必要的逻辑

### DIFF
--- a/docs/graph/bfs.md
+++ b/docs/graph/bfs.md
@@ -168,14 +168,15 @@ while (队列不为空) {
 ```cpp
 #include <bits/stdc++.h>
 using namespace std;
+
 #define INF (1 << 29)
 int n, m;
 char grid[1001][1001];
 int dist[1001][1001][4];
-int vis[1001][1001][4];
 int fx[] = {1, -1, 0, 0};
 int fy[] = {0, 0, 1, -1};
 deque<int> q;
+
 void add_front(int x, int y, int dir, int d) {
   if (d < dist[x][y][dir]) {
     dist[x][y][dir] = d;
@@ -184,6 +185,7 @@ void add_front(int x, int y, int dir, int d) {
     q.push_front(x);
   }
 }
+
 void add_back(int x, int y, int dir, int d) {
   if (d < dist[x][y][dir]) {
     dist[x][y][dir] = d;
@@ -192,6 +194,7 @@ void add_back(int x, int y, int dir, int d) {
     q.push_back(dir);
   }
 }
+
 int main() {
   cin >> n >> m;
   for (int i = 0; i < n; i++) cin >> grid[i];
@@ -207,8 +210,6 @@ int main() {
     q.pop_front();
     q.pop_front();
     q.pop_front();
-    if (vis[x][y][dir]) continue;
-    vis[x][y][dir] = true;
     int d = dist[x][y][dir];
     int nx = x + fx[dir], ny = y + fy[dir];
     if (nx >= 0 && nx < n && ny >= 0 && ny < m) add_front(nx, ny, dir, d);


### PR DESCRIPTION
考虑到 BFS 的顺序，若某个顶点 `(x,y,dir)` 已被访问过，则 `dist[x][y][dir]` 已被松弛，此时条件 `d < dist[x][y][dir]` 必为假。故移除数组 `vis`。

<!--
首先，十分感谢你花时间来给 OI Wiki 开一个 Pull Request，下面是一些你可能需要知道的信息：

- 请在 commit 的时候写比较有意义的 commit message
- 请给 PR 起比较有意义的标题。
- 如果您的 PR 可以解决某个现有的 issue，请在这个文本框的开头部分写上 fix + issue 编号。 如：fix #1622
- 关于文档内容的基本格式和基本内容规范，可以查阅 [如何参与](https://oi-wiki.org/intro/htc)。
- 请确保勾选了下方允许维护者修改的候选框（lint bot 需要在 PR 环节修正格式）

**如果有需要额外注明的内容，请写在这个文本框的开头部分 :smile: 谢谢～**
-->

**审核的同学** 请着重关注以下四方面：

1. 注意有没有 typo
2. 不论你是否熟悉相关知识，都请以初学者的角度把这个 PR 的内容阅读一遍，跟着作者的思路走，然后谈谈你的感受
3. 如果你熟悉相关知识，请按照自己的理解评估这个 PR 的内容是否合适
4. 请**尽量**保持跟进直到它被 merge 或 close
