### PR TITLE
refactor(cdn): replace cdn before deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ script:
   - npx gulp minify
   - python scripts/gen_redirect.py
   - touch ./site/.nojekyll # Stop GitHub Pages from ignoring files with underscores prefixed
+  - cp -r site/ site-cdn-pages
+  - node ./scripts/replace_cdn.js
   - set +e
 deploy:
   provider: pages
@@ -32,11 +34,8 @@ deploy:
     branch: master
 after_deploy:
   - chmod +x scripts/BaiduPusher.sh && ./scripts/BaiduPusher.sh
-  - cd /tmp
-  - git clone -b gh-pages https://github.com/OI-wiki/OI-wiki.git
-  - cd OI-wiki
+  - cd site-cdn-pages && git init
   - git checkout -b cdn-pages
-  - node ./scripts/replace_cdn.js
   - git add .
   - git config user.name "Travis Builder"
   - git config user.email "hi@oi-wiki.org"

--- a/scripts/replace_cdn.js
+++ b/scripts/replace_cdn.js
@@ -5,7 +5,7 @@ const { listDir } = require('hexo-fs');
 const { cpus } = require('os');
 const WorkerPool = require('./worker-pool');
 
-const distDir = join(dirname(__dirname) + '/site');
+const distDir = join(dirname(__dirname) + '/site-cdn-pages');
 const workerPath = join(__dirname + '/replace_cdn_worker.js');
 
 // Maxmize CPU performance


### PR DESCRIPTION
<!--
首先，十分感谢你花时间来给 OI Wiki 开一个 Pull Request，下面是一些你可能需要知道的信息：

- 请在 commit 的时候写比较有意义的 commit message
- 请给 PR 起比较有意义的标题。
- 如果您的 PR 可以解决某个现有的 issue，请在这个文本框的开头部分写上 fix + issue 编号。 如：fix #1622
- 关于文档内容的基本格式和基本内容规范，可以查阅 [如何参与](https://oi-wiki.org/intro/htc)。
- 请确保勾选了下方允许维护者修改的候选框（lint bot 需要在 PR 环节修正格式）

**如果有需要额外注明的内容，请写在这个文本框的开头部分 :smile: 谢谢～**
-->

**审核的同学** 请着重关注以下四方面：

1. 注意有没有 typo
2. 不论你是否熟悉相关知识，都请以初学者的角度把这个 PR 的内容阅读一遍，跟着作者的思路走，然后谈谈你的感受
3. 如果你熟悉相关知识，请按照自己的理解评估这个 PR 的内容是否合适
4. 请**尽量**保持跟进直到它被 merge 或 close

----

This is an emergency fix for #2290, blame @sukkaw.

- Now cdn replacement will begin right before the deployment toward `gh-pages`
- A new directory `site-cdn-pages` will be created during the replacement
- After `site` is deployed to `gh-pages`, `site-cdn-pages` will be deployed to `cdn-pages` branch as expected.



