### PR TITLE
Update java.md

### DIFF
--- a/docs/lang/java.md
+++ b/docs/lang/java.md
@@ -44,8 +44,8 @@ sudo mv jdk-14 /opt
 并在 `.bashrc` 文件末尾添加
 
 ```bash
-export JAVA_HOME="/opt/jdk-14/bin"
-export PATH=${JAVA_HOME}:$PATH
+export JAVA_HOME="/opt/jdk-14"
+export PATH=$JAVA_HOME/bin:$PATH
 ```
 
 在控制台中输入命令 `source ~/.bashrc` 即可重载。如果是使用的 zsh 或其他命令行，在 `~/.zshrc` 或对应的文件中添加上面的内容


### PR DESCRIPTION
根据惯例，`JAVA_HOME` 一般被设置为 Java 的安装目录而非安装目录下的 bin 目录。

---

**审核的同学** 请着重关注以下四方面：

1. 注意有没有 typo
2. 不论你是否熟悉相关知识，都请以初学者的角度把这个 PR 的内容阅读一遍，跟着作者的思路走，然后谈谈你的感受
3. 如果你熟悉相关知识，请按照自己的理解评估这个 PR 的内容是否合适
4. 请**尽量**保持跟进直到它被 merge 或 close
