### PR TITLE
修改例题 fusion tree 代码一处错误

### DIFF
--- a/docs/string/trie.md
+++ b/docs/string/trie.md
@@ -444,9 +444,9 @@ int marge(int a, int b) {
             if (opt == 1) {
               lztar[x]++;
               if (x != rt) {
-                if (fa[fa[x]]) trie::erase(trie::rt[fa[fa[x]]], get(fa[x]), 0);
+                if (fa[fa[x]] != -1) trie::erase(trie::rt[fa[fa[x]]], get(fa[x]), 0);
                 V[fa[x]]++;
-                if (fa[fa[x]]) trie::insert(trie::rt[fa[fa[x]]], get(fa[x]), 0);
+                if (fa[fa[x]] != -1) trie::insert(trie::rt[fa[fa[x]]], get(fa[x]), 0);
               }
               trie::addall(trie::rt[x]);
             } else if (opt == 2) {


### PR DESCRIPTION
> @Falicitas
> 题目fusion tree的第87 & 89行的if判定那写错了，应改为if(fa[fa[x]]!=-1)云云，由于rt周围的点若被修改会RE（虽然数据能过）

这位同学发现了一处错误，数据能过，但实际上是不对的。

这个代码是我写的，没有注意这个地方，现已改正。

对我的疏忽而抱歉，同时感谢这个同学的阅读。

<!--
首先，十分感谢你花时间来给 OI Wiki 开一个 Pull Request，下面是一些你可能需要知道的信息：

- 请在 commit 的时候写比较有意义的 commit message
- 请给 PR 起比较有意义的标题。
- 如果您的 PR 可以解决某个现有的 issue，请在这个文本框的开头部分写上 fix + issue 编号。 如：fix #1622
- 关于文档内容的基本格式和基本内容规范，可以查阅 [如何参与](https://oi-wiki.org/intro/htc)。
- 请确保勾选了下方允许维护者修改的候选框（lint bot 需要在 PR 环节修正格式）

**如果有需要额外注明的内容，请写在这个文本框的开头部分 :smile: 谢谢～**
-->

**审核的同学** 请着重关注以下四方面：

1. 注意有没有 typo
2. 不论你是否熟悉相关知识，都请以初学者的角度把这个 PR 的内容阅读一遍，跟着作者的思路走，然后谈谈你的感受
3. 如果你熟悉相关知识，请按照自己的理解评估这个 PR 的内容是否合适
4. 请**尽量**保持跟进直到它被 merge 或 close
