### PR TITLE
Fixed a bug in the C++ example of radix sort

### DIFF
--- a/docs/basic/radix-sort.md
+++ b/docs/basic/radix-sort.md
@@ -73,7 +73,7 @@ void counting_sort(int p) {
   for (int i = 1; i <= n; ++i) ++cnt[a[i].key[p]];
   for (int i = 1; i <= w[p]; ++i) cnt[i] += cnt[i - 1];
   // 为保证排序的稳定性，此处循环i应从n到1
-  // 即当两元素关键字的值相同时，原先排在后面的元素在排序后仍应排在后面 
+  // 即当两元素关键字的值相同时，原先排在后面的元素在排序后仍应排在后面
   for (int i = n; i >= 1; --i) b[cnt[a[i].key[p]]--] = a[i];
   memcpy(a, b, sizeof(a));
 }

--- a/docs/basic/radix-sort.md
+++ b/docs/basic/radix-sort.md
@@ -72,7 +72,9 @@ void counting_sort(int p) {
   memset(cnt, 0, sizeof(cnt));
   for (int i = 1; i <= n; ++i) ++cnt[a[i].key[p]];
   for (int i = 1; i <= w[p]; ++i) cnt[i] += cnt[i - 1];
-  for (int i = 1; i <= n; ++i) b[cnt[a[i].key[p]]--] = a[i];
+  // 为保证排序的稳定性，此处循环i应从n到1
+  // 即当两元素关键字的值相同时，原先排在后面的元素在排序后仍应排在后面 
+  for (int i = n; i >= 1; --i) b[cnt[a[i].key[p]]--] = a[i];
   memcpy(a, b, sizeof(a));
 }
 


### PR DESCRIPTION
Thanks for reviewing this.

The original code will generate an **INCORRECT** output on the following testcase:
```c++
int main()
{
    k = 2;
    w[1] = w[2] = 2;
    n = 3;
    a[1].key[1] = 2, a[1].key[2] = 1;
    a[2].key[1] = 1, a[2].key[2] = 1;
    a[3].key[1] = 1, a[3].key[2] = 2;
    radix_sort();
    cout << a[1].key[1] << a[1].key[2] << endl;
    cout << a[2].key[1] << a[2].key[2] << endl;
    cout << a[3].key[1] << a[3].key[2] << endl;
    /*
    Incorrect Output:
    12
    11
    21
    */
    return 0;
}
```
Ouput is now **CORRECT** after fixing the bug.
```c++
int main()
{
    k = 2;
    w[1] = w[2] = 2;
    n = 3;
    a[1].key[1] = 2, a[1].key[2] = 1;
    a[2].key[1] = 1, a[2].key[2] = 1;
    a[3].key[1] = 1, a[3].key[2] = 2;
    radix_sort();
    cout << a[1].key[1] << a[1].key[2] << endl;
    cout << a[2].key[1] << a[2].key[2] << endl;
    cout << a[3].key[1] << a[3].key[2] << endl;
    /*
    Correct Output:
    11
    12
    21
    */
    return 0;
}
```
