### PR TITLE
修复代码块行号（fix #2114 & #2160）

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -477,6 +477,8 @@ markdown_extensions:
   - pymdownx.details
   - pymdownx.emoji:
       emoji_generator: !!python/name:pymdownx.emoji.to_svg
+  - pymdownx.highlight:
+      linenums: true
   - pymdownx.inlinehilite
   - pymdownx.keys
   - pymdownx.magiclink

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 mkdocs>=1
 pymdown-extensions
-Pygments
+Pygments>=2.2,<2.4


### PR DESCRIPTION
~~错位问题是因为代码被 \<pre\> 和 \<code\> 套了两层，一层一个 padding，我试试能不能修~~

已解决，错误原因：

> https://python-markdown.github.io/extensions/code_hilite/
>
> Additionally, if using Pygments >= 2.4, the output will be wrapped in `<code>` tags, whereas earlier versions will not.

---

**审核的同学** 请着重关注以下四方面：

1. 注意有没有 typo
2. 不论你是否熟悉相关知识，都请以初学者的角度把这个 PR 的内容阅读一遍，跟着作者的思路走，然后谈谈你的感受
3. 如果你熟悉相关知识，请按照自己的理解评估这个 PR 的内容是否合适
4. 请**尽量**保持跟进直到它被 merge 或 close
