### PR TITLE
修改了“求一个原根”的证明的错误

### DIFF
--- a/docs/math/primitive-root.md
+++ b/docs/math/primitive-root.md
@@ -37,7 +37,7 @@ $$
 
 又有 $t<\varphi(p)$ ，故 $\gcd(t,\varphi(p))\leqslant t<\varphi(p)$ 。
 
-又 $\gcd(t,\varphi(p))\mid(\varphi(p))$ ，故 $\gcd(t,\varphi(p))$ 必至少整除 $a^{\frac{\varphi(p)}{d_{1}}},a^{\frac{\varphi(p)}{d_{2}}},\ldots,a^{\frac{\varphi(p)}{d_{m}}}$ 中的至少一个，设 $\gcd(t,\varphi(p))\mid a^{\frac{\varphi(p)}{d_{i}}}$ ，则 $a^{\frac{\varphi(p)}{d_{i}}}\equiv a^{\gcd(t,\varphi(p))}\equiv 1\pmod{p}$ 。
+又 $\gcd(t,\varphi(p))\mid(\varphi(p))$ ，故 $\gcd(t,\varphi(p))$ 必至少整除 ${\frac{\varphi(p)}{d_{1}}},{\frac{\varphi(p)}{d_{2}}},\ldots,{\frac{\varphi(p)}{d_{m}}}$ 中的至少一个，设 $\gcd(t,\varphi(p))\mid {\frac{\varphi(p)}{d_{i}}}$ ，则 $a^{\frac{\varphi(p)}{d_{i}}}\equiv a^{\gcd(t,\varphi(p))}\equiv 1\pmod{p}$ 。
 
 故假设不成立。
 


### PR DESCRIPTION
个人的理解是\gcd(t,\varphi(p))整除{\frac{\varphi(p)}{d_{i}}}，这里应该是和a没关系的。

<!--
首先，十分感谢你花时间来给 OI Wiki 开一个 Pull Request，下面是一些你可能需要知道的信息：

- 请在 commit 的时候写比较有意义的 commit message
- 请给 PR 起比较有意义的标题。
- 如果您的 PR 可以解决某个现有的 issue，请在这个文本框的开头部分写上 fix + issue 编号。 如：fix #1622
- 关于文档内容的基本格式和基本内容规范，可以查阅 [如何参与](https://oi-wiki.org/intro/htc)。
- 请确保勾选了下方允许维护者修改的候选框（lint bot 需要在 PR 环节修正格式）

**如果有需要额外注明的内容，请写在这个文本框的开头部分 :smile: 谢谢～**
-->

**审核的同学** 请着重关注以下四方面：

1. 注意有没有 typo
2. 不论你是否熟悉相关知识，都请以初学者的角度把这个 PR 的内容阅读一遍，跟着作者的思路走，然后谈谈你的感受
3. 如果你熟悉相关知识，请按照自己的理解评估这个 PR 的内容是否合适
4. 请**尽量**保持跟进直到它被 merge 或 close
