### PR TITLE
修改部署脚本在mac上出错的问题

### DIFF
--- a/scripts/install_theme.sh
+++ b/scripts/install_theme.sh
@@ -6,4 +6,9 @@ if [ ! -d "mkdocs-material" ] ; then
   git clone --depth=1 https://github.com/OI-wiki/mkdocs-material.git
 fi
 
-sed -i "s/name: 'material'/name: null\n  custom_dir: 'mkdocs-material\/material'\n  static_templates:\n    - 404.html/g" mkdocs.yml
+if [ "$(uname)" == "Darwin" ] ; then
+  # macOS sed -i 需要添加""表示不备份修改
+  sed -i "" "s/name: 'material'/name: null\n  custom_dir: 'mkdocs-material\/material'\n  static_templates:\n    - 404.html/g" mkdocs.yml
+else
+  sed -i "s/name: 'material'/name: null\n  custom_dir: 'mkdocs-material\/material'\n  static_templates:\n    - 404.html/g" mkdocs.yml
+fi


### PR DESCRIPTION
与内容无关
macOS sed -i 需要带一个字符串作为备份源文件的文件名称 否则会出错

<!--
首先，十分感谢你花时间来给 OI Wiki 开一个 Pull Request，下面是一些你可能需要知道的信息：

- 请在 commit 的时候写比较有意义的 commit message
- 请给 PR 起比较有意义的标题。
- 如果您的 PR 可以解决某个现有的 issue，请在这个文本框的开头部分写上 fix + issue 编号。 如：fix #1622
- 关于文档内容的基本格式和基本内容规范，可以查阅 [如何参与](https://oi-wiki.org/intro/htc)。
- 请确保勾选了下方允许维护者修改的候选框（lint bot 需要在 PR 环节修正格式）

**如果有需要额外注明的内容，请写在这个文本框的开头部分 :smile: 谢谢～**
-->

