### PR TITLE
Update splay.md

### DIFF
--- a/docs/ds/splay.md
+++ b/docs/ds/splay.md
@@ -258,7 +258,6 @@ void del(int k) {
     return;
   }
   int cnr = rt, x = pre();
-  splay(x);
   fa[ch[cnr][1]] = x;
   ch[x][1] = ch[cnr][1];
   clear(cnr);
@@ -398,7 +397,6 @@ struct Splay {
     }
     int cnr = rt;
     int x = pre();
-    splay(x);
     fa[ch[cnr][1]] = x;
     ch[x][1] = ch[cnr][1];
     clear(cnr);


### PR DESCRIPTION
修改了删除节点里查找x的前驱后还要多splay一次的无意义代码，pre的返回值x在返回之前已经被splay到root了，不必再splay(x)