### PR TITLE
修正最长不下降子序列nlogn解法中的代码错误

### DIFF
--- a/docs/dp/basic.md
+++ b/docs/dp/basic.md
@@ -160,7 +160,7 @@ for (int i = 0; i < n; ++i) scanf("%d", a + i);
 memset(dp, 0x1f, sizeof dp);
 mx = dp[0];
 for (int i = 0; i < n; ++i) {
-  *std::lower_bound(dp, dp + n, a[i]) = a[i];
+  *std::upper_bound(dp, dp + n, a[i]) = a[i];
 }
 ans = 0;
 while (dp[ans] != mx) ++ans;


### PR DESCRIPTION
如该解法中代码上面的算法描述，在dp中找到第一个大于a[i]的元素，则应该使用upper_bound，而不是lower_bound。

<!--
首先，十分感谢你花时间来给 OI Wiki 开一个 Pull Request，下面是一些你可能需要知道的信息：

- 请在 commit 的时候写比较有意义的 commit message
- 请给 PR 起比较有意义的标题。
- 如果您的 PR 可以解决某个现有的 issue，请在这个文本框的开头部分写上 fix + issue 编号。 如：fix #1622
- 关于文档内容的基本格式和基本内容规范，可以查阅 [如何参与](https://oi-wiki.org/intro/htc)。
- 请确保勾选了下方允许维护者修改的候选框（lint bot 需要在 PR 环节修正格式）

**如果有需要额外注明的内容，请写在这个文本框的开头部分 :smile: 谢谢～**
-->

**审核的同学** 请着重关注以下四方面：

1. 注意有没有 typo
2. 不论你是否熟悉相关知识，都请以初学者的角度把这个 PR 的内容阅读一遍，跟着作者的思路走，然后谈谈你的感受
3. 如果你熟悉相关知识，请按照自己的理解评估这个 PR 的内容是否合适
4. 请**尽量**保持跟进直到它被 merge 或 close
