### PR TITLE
fix(typo): fix a typo in a formula in math/prime

### DIFF
--- a/docs/math/prime.md
+++ b/docs/math/prime.md
@@ -76,7 +76,7 @@ bool millerRabin(int n) {
 
 #### 二次探测定理
 
-如果 $p$ 是奇素数，则 $x^2 \equiv 1 \bmod p$ 的解为 $x = 1$ 或者 $x = p - 1 (\bmod p)$ ;
+如果 $p$ 是奇素数，则 $x^2 \equiv 1 \bmod p$ 的解为 $x \equiv 1$ 或者 $x \equiv p - 1 (\bmod p)$ ;
 
 ### 实现
 


### PR DESCRIPTION
fix(typo): fix a typo in a formula in math/prime

It obviously should be `\equiv` not `=`.