### PR TITLE
修改了一处代码错误

### DIFF
--- a/docs/math/sieve.md
+++ b/docs/math/sieve.md
@@ -83,17 +83,14 @@ void init() {
     for (int j = 0; j < cnt; ++j) {
       if (1ll * i * pri[j] >= MAXN) break;
       vis[i * pri[j]] = 1;
-      if (i % pri[j]) {
-        phi[i * pri[j]] = phi[i] * (pri[j] - 1);
-      } else {
-        // i % pri[j] == 0
-        // 换言之，i 之前被 pri[j] 筛过了
-        // 由于 pri 里面质数是从小到大的，所以 i 乘上其他的质数的结果一定也是
-        // pri[j] 的倍数 它们都被筛过了，就不需要再筛了，所以这里直接 break
-        // 掉就好了
-        phi[i * pri[j]] = phi[i] * pri[j];
+      phi[i * pri[j]] = phi[i] * (pri[j] - 1);
+      if (i % pri[j] == 0)
         break;
-      }
+      // i % pri[j] == 0
+      // 换言之，i 之前被 pri[j] 筛过了
+      // 由于 pri 里面质数是从小到大的，所以 i 乘上其他的质数的结果一定也是
+      // pri[j]的倍数，后续也至少会被pri[j]筛到，所以这里直接 break
+      // 掉就好了
     }
   }
 }

--- a/docs/math/sieve.md
+++ b/docs/math/sieve.md
@@ -84,8 +84,7 @@ void init() {
       if (1ll * i * pri[j] >= MAXN) break;
       vis[i * pri[j]] = 1;
       phi[i * pri[j]] = phi[i] * (pri[j] - 1);
-      if (i % pri[j] == 0)
-        break;
+      if (i % pri[j] == 0) break;
       // i % pri[j] == 0
       // 换言之，i 之前被 pri[j] 筛过了
       // 由于 pri 里面质数是从小到大的，所以 i 乘上其他的质数的结果一定也是


### PR DESCRIPTION
`// pri[j] 的倍数 它们都被筛过了，就不需要再筛了，所以这里直接 break`
我认为这句注释有误，不是被筛过了，而是后续一定会被pri[j]筛。
改正并简化了更新phi数组处的if-else结构。

<!--
首先，十分感谢你花时间来给 OI Wiki 开一个 Pull Request，下面是一些你可能需要知道的信息：

- 请在 commit 的时候写比较有意义的 commit message
- 请给 PR 起比较有意义的标题。
- 如果您的 PR 可以解决某个现有的 issue，请在这个文本框的开头部分写上 fix + issue 编号。 如：fix #1622
- 关于文档内容的基本格式和基本内容规范，可以查阅 [如何参与](https://oi-wiki.org/intro/htc)。
- 请确保勾选了下方允许维护者修改的候选框（lint bot 需要在 PR 环节修正格式）

**如果有需要额外注明的内容，请写在这个文本框的开头部分 :smile: 谢谢～**
-->

**审核的同学** 请着重关注以下四方面：

1. 注意有没有 typo
2. 不论你是否熟悉相关知识，都请以初学者的角度把这个 PR 的内容阅读一遍，跟着作者的思路走，然后谈谈你的感受
3. 如果你熟悉相关知识，请按照自己的理解评估这个 PR 的内容是否合适
4. 请**尽量**保持跟进直到它被 merge 或 close
