### PR TITLE
fix:(sparse-table.md) Fix runtime error in example code

### DIFF
--- a/docs/ds/sparse-table.md
+++ b/docs/ds/sparse-table.md
@@ -55,7 +55,7 @@ ST 表基于 [倍增](../basic/binary-lifting.md) 思想，可以做到 $\Theta(
 using namespace std;
 const int logn = 21;
 const int maxn = 2000001;
-int f[maxn][logn], Logn[maxn];
+int f[maxn][logn + 1], Logn[maxn + 1];
 inline int read() {
   char c = getchar();
   int x = 0, f = 1;


### PR DESCRIPTION
Fix runtime error in example code.

定义数组大小为`logn`, 但是在 [第83行](https://github.com/OI-wiki/OI-wiki/pull/2751/files#diff-3c3a736232b812155587f9c4d5792e4475f4942aed73e0f0dbf99a56c71cdc02L83) 访问了下标为`logn`的地方.

修复数组大小为`logn+1`.
<!--
首先，十分感谢你花时间来给 OI Wiki 开一个 Pull Request，下面是一些你可能需要知道的信息：

- 请在 commit 的时候写比较有意义的 commit message
- 请给 PR 起比较有意义的标题。
- 如果您的 PR 可以解决某个现有的 issue，请在这个文本框的开头部分写上 fix + issue 编号。 如：fix #1622
- 关于文档内容的基本格式和基本内容规范，可以查阅 [如何参与](https://oi-wiki.org/intro/htc)。
- 请确保勾选了下方允许维护者修改的候选框（lint bot 需要在 PR 环节修正格式）

**如果有需要额外注明的内容，请写在这个文本框的开头部分 :smile: 谢谢～**
-->

**审核的同学** 请着重关注以下四方面：

1. 注意有没有 typo
2. 不论你是否熟悉相关知识，都请以初学者的角度把这个 PR 的内容阅读一遍，跟着作者的思路走，然后谈谈你的感受
3. 如果你熟悉相关知识，请按照自己的理解评估这个 PR 的内容是否合适
4. 请**尽量**保持跟进直到它被 merge 或 close
