### PR TITLE
修改完全背包的例题代码

### DIFF
--- a/docs/dp/knapsack.md
+++ b/docs/dp/knapsack.md
@@ -104,16 +104,21 @@ $$
 ??? 例题代码
     ```cpp
     #include <iostream>
-    const int maxn = 1e5 + 10;
-    int n, W, w[maxn], v[maxn], f[maxn];
-    int main() {
-      std::cin >> W >> n;
-      for (int i = 1; i <= n; i++) std::cin >> w[i] >> v[i];
-      for (int i = 1; i <= n; i++)
-        for (int l = w[i]; l <= W; l++)
-          if (f[l - w[i]] + v[i] > f[l]) f[l] = f[l - w[i]] + v[i];
-      std::cout << f[W];
-      return 0;
+    const int maxn = 1e4 + 5;
+    const int maxW = 1e7 + 5;
+    int n, W, w[maxn], v[maxn];
+    long long f[maxW];
+    int main()
+    {
+        std::cin >> W >> n;
+        for (int i = 1; i <= n; i++)
+            std::cin >> w[i] >> v[i];
+        for (int i = 1; i <= n; i++)
+            for (int l = w[i]; l <= W; l++)
+                if (f[l - w[i]] + v[i] > f[l])
+                    f[l] = f[l - w[i]] + v[i];
+        std::cout << f[W];
+        return 0;
     }
     ```
 


### PR DESCRIPTION
可能是洛谷更新题目和数据了，原来的代码有两个地方不对，一是数组的大小不对，二是 f 数组应该开 `long long`。

<!--
首先，十分感谢你花时间来给 OI Wiki 开一个 Pull Request，下面是一些你可能需要知道的信息：

- 请在 commit 的时候写比较有意义的 commit message
- 请给 PR 起比较有意义的标题。
- 如果您的 PR 可以解决某个现有的 issue，请在这个文本框的开头部分写上 fix + issue 编号。 如：fix #1622
- 关于文档内容的基本格式和基本内容规范，可以查阅 [如何参与](https://oi-wiki.org/intro/htc)。
- 请确保勾选了下方允许维护者修改的候选框（lint bot 需要在 PR 环节修正格式）

**如果有需要额外注明的内容，请写在这个文本框的开头部分 :smile: 谢谢～**
-->

**审核的同学** 请着重关注以下四方面：

1. 注意有没有 typo
2. 不论你是否熟悉相关知识，都请以初学者的角度把这个 PR 的内容阅读一遍，跟着作者的思路走，然后谈谈你的感受
3. 如果你熟悉相关知识，请按照自己的理解评估这个 PR 的内容是否合适
4. 请**尽量**保持跟进直到它被 merge 或 close
