### PR TITLE
feat(intro/format.md): 添加将引用链接存于互联网档案馆的提示

### DIFF
--- a/docs/intro/format.md
+++ b/docs/intro/format.md
@@ -20,7 +20,7 @@
 
 - 推荐使用 SVG 格式的图片[^ref4]，以获取较好的清晰度和缩放效果。
 
-- 请确保您的文档中的引用链接的稳定性。 **不推荐** 引用 **自建** 服务中的资源（如自建 OJ 里的题目）。
+- 请确保您的文档中的引用链接的稳定性。 **不推荐** 引用 **自建** 服务中的资源（如自建 OJ 里的题目）。建议在添加时同时将该外链存于互联网档案馆[^webarchive]，以防无法替代的链接失效。
 
 - 站内链接请去掉网站域名，并且使用相对路径链接对应 `.md` 文件。例如，在本页面（ `intro/format` ）中链接杂项简介（ `misc` ），应使用 `[杂项简介](../misc/index.md)` 。
 
@@ -482,3 +482,5 @@ $$
 [^ref3]:  [我的公式为什么在目录里没有正常显示？好像双倍了](faq.md) 
 
 [^ref4]:  [SVG|MDN](https://developer.mozilla.org/zh-CN/docs/Web/SVG) 
+
+[^webarchive]: [Save Page in Internet Archive](https://web.archive.org/save/)


### PR DESCRIPTION
虽然我们已在格式手册中提示使用稳定的引用链接，但是仍然不能避免链接失效的情况。
在这方面，维基百科的做法给我们一个提示，我们可以在添加引用链接的同时，将其保存备份与[互联网档案馆的时光机](https://web.archive.org/)。
维基百科上常见的“存档于”：
![维基百科上常见的“存档于”](https://user-images.githubusercontent.com/43064781/105897305-f3df1400-6052-11eb-9a1a-e70c86231352.png)
而更遥远的想法，则是准备一个 Bot/CI，自动地将 OI Wiki 中的引用链接定时地保存于互联网档案馆，并且定期更新。
更进一步还可以，当链接失效的时候自动用互联网档案馆的链接替换失效链接。

这只是一个小小的想法，希望与大家一同讨论。