### PR TITLE
fix(tool/judgers.md): wrong usage in building lemon

### DIFF
--- a/docs/tools/judgers.md
+++ b/docs/tools/judgers.md
@@ -174,13 +174,11 @@ Ubuntu：
 ```bash
 sudo apt update
 sudo apt install qt5-default build-essential git -y
-git clone --depth=1 http://github.com/menci/lemon.git
+git clone --depth=1 https://github.com/Menci/Lemon.git
 cd lemon
-# 可以修改 make 文件来调整 make job 的线程数
-sed -i 's/make $/make -j 1 $/g' make
-./make
-cp Lemon ~
-cd ..
+# 可以修改 -j 后面的数字来调整 make job 的线程数
+./make -j2
+sudo install -Dm755 -t /usr/bin/ Lemon
 ```
 
 ### 数据格式

--- a/docs/tools/judgers.md
+++ b/docs/tools/judgers.md
@@ -181,6 +181,8 @@ cd lemon
 sudo install -Dm755 -t /usr/bin/ Lemon
 ```
 
+如要编译 LemonLime，请参阅 LemonLime 的[编译手册](https://github.com/Project-LemonLime/Project_LemonLime/blob/master/BUILD.md)。
+
 ### 数据格式
 
 首先打开 lemon 选择“新建试题”，然后打开新建试题的文件夹。

--- a/docs/tools/judgers.md
+++ b/docs/tools/judgers.md
@@ -1,4 +1,4 @@
-author: Ir1d, HeRaNO, NachtgeistW, i-Yirannn, bear-good, ranwen, ayalhw, billchenchina, Tiger3018, Xeonacid
+author: Ir1d, HeRaNO, NachtgeistW, i-Yirannn, bear-good, ranwen, CoelacanthusHex, billchenchina, Tiger3018, Xeonacid
 
  **评测软件** 是用于本地测试分数的软件。使用者在将代码提交到 OJ 前，可以使用评测软件对自己的程序估分。
 


### PR DESCRIPTION
1.  we can pass parameter into `./make` instead of using `sed` to modify the file,
    `-jn` can be passed although `-j n` can't.
2.  we can install the executable file into PATH instead of throwing it into home dir.

the result of git blame: https://github.com/OI-wiki/OI-wiki/commit/47acc594f2d94423d319a7b1ee83546ad29552a6
