### PR TITLE
fix(tools/editor/GUIDE): a workaround for some error in checkinstall

### DIFF
--- a/docs/tools/editor/guide.md
+++ b/docs/tools/editor/guide.md
@@ -36,7 +36,7 @@ sudo apt install -y libpng12 libsm6 libice6 libxi6 libxrender1 libxrandr libfree
 wget -c http://download.noi.cn/T/noi/GUIDE-1.0.2-ubuntu.tar
 tar -xvf GUIDE-1.0.2-ubuntu.tar
 cd GUIDE-1.0.2-ubuntu
-echo "install:\n\tinstall -Dm755 -t /usr/bin GUIDE\n\tinstall -Dm644 -t /usr/share/ lang_en.qm\n\tinstall -Dm644 -t /usr/share/ apis\n\tmkdir -p /usr/share/doc/GUIDE/html/\n\tcp -r doc/*  /usr/share/doc/GUIDE/html/" > Makefile
+echo "install:\n\tinstall -Dm755 -t /usr/bin GUIDE\n\tinstall -Dm644 -t /usr/share/ lang_en.qm\n\tmkdir -p /usr/share/apis/ && cp -r apis/* /usr/share/apis/\n\tmkdir -p /usr/share/doc/GUIDE/ && mkdir -p /usr/share/doc/GUIDE/html/ && cp -r doc/*  /usr/share/doc/GUIDE/html/" > Makefile
 sudo apt install -y checkinstall
 sudo checkinstall --pkgname "GUIDE" --pkgversion "1.0.2" -y
 ```
@@ -52,7 +52,7 @@ sudo zypper install -n {libpng12-0,libSM6,libICE6,libXi6,libXrender1,libXrandr2,
 wget -c http://download.noi.cn/T/noi/GUIDE-1.0.2-ubuntu.tar
 tar -xvf GUIDE-1.0.2-ubuntu.tar
 cd GUIDE-1.0.2-ubuntu
-echo "install:\n\tinstall -Dm755 -t /usr/bin GUIDE\n\tinstall -Dm644 -t /usr/share/ lang_en.qm\n\tinstall -Dm644 -t /usr/share/ apis\n\tmkdir -p /usr/share/doc/GUIDE/html/\n\tcp -r doc/*  /usr/share/doc/GUIDE/html/" > Makefile
+echo "install:\n\tinstall -Dm755 -t /usr/bin GUIDE\n\tinstall -Dm644 -t /usr/share/ lang_en.qm\n\tmkdir -p /usr/share/apis/ && cp -r apis/* /usr/share/apis/\n\tmkdir -p /usr/share/doc/GUIDE/ && mkdir -p /usr/share/doc/GUIDE/html/ && cp -r doc/*  /usr/share/doc/GUIDE/html/" > Makefile
 sudo checkinstall --pkgname "GUIDE" --pkgversion "1.0.2" -y -rpmi
 ```
 


### PR DESCRIPTION
说实话这个 Workaround 我是不太想加的，但是我在测试的时候确实遇到了反复的
玄学错误，典型例子是这样的：
```log
mkdir: cannot create directory ‘/usr/share/doc/GUIDE’: No such file or directory
```
分开创建目录可以解决这个问题，就好像 `-p` 参数被忽略了一样…………
为了防止不必要的麻烦，我觉得还是加上为好


