### PR TITLE
fix parallel-binsearch.md

### DIFF
--- a/docs/misc/parallel-binsearch.md
+++ b/docs/misc/parallel-binsearch.md
@@ -85,7 +85,7 @@ void solve(int l, int r, vector<Query> q) {
   }
   vector<int> q1, q2;
   for (unsigned i = 0; i < q.size(); i++)
-    if (check(m) <= q[i].k)
+    if (q[i].k <=check(m))
       q1.push_back(q[i]);
     else
       q[i].k -= check(m), q2.push_back(q[i]);

--- a/docs/misc/parallel-binsearch.md
+++ b/docs/misc/parallel-binsearch.md
@@ -85,7 +85,7 @@ void solve(int l, int r, vector<Query> q) {
   }
   vector<int> q1, q2;
   for (unsigned i = 0; i < q.size(); i++)
-    if (q[i].k <=check(m))
+    if (q[i].k <= check(m))
       q1.push_back(q[i]);
     else
       q[i].k -= check(m), q2.push_back(q[i]);


### PR DESCRIPTION
对于小于等于二分的mid的答案，应该划到左边，而不是将mid小于等于的答案划到左边