### PR TITLE
fix(mobius.md): 更改了“补充结论”中\iff和\implies的运用错误

### DIFF
--- a/docs/math/mobius.md
+++ b/docs/math/mobius.md
@@ -238,11 +238,11 @@ $$
 
 ### 补充结论
 
-反演结论：$\displaystyle [\gcd(i,j)=1] \iff\sum_{d\mid\gcd(i,j)}\mu(d)$
+反演结论：$\displaystyle [\gcd(i,j)=1]=\sum_{d\mid\gcd(i,j)}\mu(d)$
 
 **直接推导**：如果看懂了上一个结论，这个结论稍加思考便可以推出：如果 $\gcd(i,j)=1$ 的话，那么代表着我们按上个结论中枚举的那个 $n$ 是 $1$，也就是式子的值是 $1$，反之，有一个与 $[\gcd(i,j)=1]$ 相同的值：$0$
 
-**利用 $\varepsilon$ 函数**：根据上一结论，$[\gcd(i,j)=1]\implies \varepsilon(\gcd(i,j))$，将 $\varepsilon$ 展开即可。
+**利用 $\varepsilon$ 函数**：根据上一结论，$[\gcd(i,j)=1]=\varepsilon(\gcd(i,j))$，将 $\varepsilon$ 展开即可。
 
 ### 线性筛
 


### PR DESCRIPTION
补充结论中两个第一个和第三个LeTeX公式中的双箭头(\iff)和右箭头(\implies)运用错误，两边都是表达式，应用等号而不是箭头。
个人觉得：
若是表示两个等式/不等式的条件关系，应用箭头；
如果表示两个表达式相等/不相等的关系，应用等号/不等号。