### PR TITLE
feat: fast CI git clone

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -34,7 +34,7 @@ jobs:
             wget -q "https://github.com/stipub/stixfonts/raw/73d7c426993abacea44288aded4e81b568d57ed1/zipfiles/STIXv2.0.2.zip" -O stix.zip
             unzip -q stix.zip
             wget -q "https://github.com/adobe-fonts/source-han-super-otc/releases/download/20190603/SourceHan.ttc"
-            git clone https://github.com/alif-type/xits
+            git clone https://github.com/alif-type/xits --depth=1
             cp xits/*.otf /usr/share/fonts
             wget https://mirrors.sjtug.sjtu.edu.cn/ctan/fonts/fandol.zip
             unzip -q fandol.zip
@@ -46,7 +46,7 @@ jobs:
             cp *.ttc /usr/share/fonts
             fc-cache
 
-            git clone https://github.com/OI-wiki/OI-Wiki-export.git
+            git clone https://github.com/OI-wiki/OI-Wiki-export.git --depth=1
             cd ./OI-Wiki-export/oi-wiki-export
             npm i
             node index.js ../../


### PR DESCRIPTION
构建PDF时只clone最近的一个版本 加快构建速度 节约资源