### PR TITLE
Fix(BST): Fix insert()

### DIFF
--- a/docs/ds/bst.md
+++ b/docs/ds/bst.md
@@ -70,6 +70,7 @@ void insert(int& o, int v) {
   if (!o) {
     val[o = ++sum] = v;
     cnt[o] = siz[o] = 1;
+    lc[o] = rc[o] = 0;
     return;
   }
   siz[o]++;


### PR DESCRIPTION
> `insert` 函数里面没有设置 `lc[o]` 和 `rc[o]` 的值, 那后面的操作根本进行不了啊

_Originally posted by @huaruoji in https://github.com/OI-wiki/gitment/issues/335#issuecomment-820830898_