### PR TITLE
fix(lct.md): fix `Find()`

### DIFF
--- a/docs/ds/lct.md
+++ b/docs/ds/lct.md
@@ -337,7 +337,7 @@ inline void Cut(int x, int p) {
 
 ```cpp
 inline int Find(int p) {
-  Access(p), Splay(p)， pushDown(p);
+  Access(p), Splay(p) ， pushDown(p);
   while (ls) p = ls, pushDown(p);
   Splay(p);
   return p;

--- a/docs/ds/lct.md
+++ b/docs/ds/lct.md
@@ -337,8 +337,8 @@ inline void Cut(int x, int p) {
 
 ```cpp
 inline int Find(int p) {
-  Access(p), Splay(p);
-  while (ls) pushDown(p), p = ls;
+  Access(p), Splay(p)， pushDown(p);
+  while (ls) p = ls, pushDown(p);
   Splay(p);
   return p;
 }

--- a/docs/ds/lct.md
+++ b/docs/ds/lct.md
@@ -337,7 +337,7 @@ inline void Cut(int x, int p) {
 
 ```cpp
 inline int Find(int p) {
-  Access(p), Splay(p) ， pushDown(p);
+  Access(p), Splay(p), pushDown(p);
   while (ls) p = ls, pushDown(p);
   Splay(p);
   return p;


### PR DESCRIPTION
原先的写法中判断是否有左儿子在 pushDown 前，可能会出问题。
实际上绝大多数题目中都可以证明这里不需要 pushDown，所以原先代码能在不少题目上 AC。但是对于魔改的 LCT 这里可能会导致错误。