### PR TITLE
明确lambda类型

### DIFF
--- a/docs/lang/csl/container-adapter.md
+++ b/docs/lang/csl/container-adapter.md
@@ -108,7 +108,9 @@ std::priority_queue<TypeName, Container, Compare> q;
 
 // 从 C++11 开始，如果使用 lambda 函数自定义 Compare
 // 则需要将其作为构造函数的参数代入，如：
-auto cmp = [](const auto &l, const auto &r) { return l.second < r.second; };
+auto cmp = [](const std::pair<int, int> &l, const std::pair<int, int> &r) { 
+  return l.second < r.second; 
+};
 std::priority_queue<std::pair<int, int>, std::vector<std::pair<int, int> >,
                     decltype(cmp)>
     pq(cmp);

--- a/docs/lang/csl/container-adapter.md
+++ b/docs/lang/csl/container-adapter.md
@@ -108,8 +108,8 @@ std::priority_queue<TypeName, Container, Compare> q;
 
 // 从 C++11 开始，如果使用 lambda 函数自定义 Compare
 // 则需要将其作为构造函数的参数代入，如：
-auto cmp = [](const std::pair<int, int> &l, const std::pair<int, int> &r) { 
-  return l.second < r.second; 
+auto cmp = [](const std::pair<int, int> &l, const std::pair<int, int> &r) {
+  return l.second < r.second;
 };
 std::priority_queue<std::pair<int, int>, std::vector<std::pair<int, int> >,
                     decltype(cmp)>


### PR DESCRIPTION
针对 https://github.com/OI-wiki/OI-wiki/pull/3127#issuecomment-826809173 进行补充。
C++14后lambda参数支持类型推导的特性在语言部分已经写有，此处不再补充。此处不假设代码在C++14标下编译，因此把类型补全。

<!--
首先，十分感谢你花时间来给 OI Wiki 开一个 Pull Request，下面是一些你可能需要知道的信息：

- 请在 commit 的时候写比较有意义的 commit message
- 请给 PR 起比较有意义的标题。
- 如果您的 PR 可以解决某个现有的 issue，请在这个文本框的开头部分写上 fix + issue 编号。 如：fix #1622
- 关于文档内容的基本格式和基本内容规范，可以查阅 [如何参与](https://oi-wiki.org/intro/htc)。
- 请确保勾选了下方允许维护者修改的候选框（lint bot 需要在 PR 环节修正格式）

**如果有需要额外注明的内容，请写在这个文本框的开头部分 :smile: 谢谢～**
-->

**审核的同学** 请着重关注以下四方面：

1. 注意有没有 typo
2. 不论你是否熟悉相关知识，都请以初学者的角度把这个 PR 的内容阅读一遍，跟着作者的思路走，然后谈谈你的感受
3. 如果你熟悉相关知识，请按照自己的理解评估这个 PR 的内容是否合适
4. 请**尽量**保持跟进直到它被 merge 或 close
