### PR TITLE
fix(mobius.md): 修订了对于倍数形式的证明中的下标范围.

### DIFF
--- a/docs/math/mobius.md
+++ b/docs/math/mobius.md
@@ -420,8 +420,8 @@ $$
 &\sum_{n|d}{\mu(\frac{d}{n})f(d)} \\ 
     =& \sum_{k=1}^{+\infty}{\mu(k)f(kn)}
     = \sum_{k=1}^{+\infty}{\mu(k)\sum_{kn|d}{g(d)}} \\
-    =& \sum_{n|d}{g(d)\sum_{k|\frac{n}{d}}{\mu(k)}}
-    = \sum_{n|d}{g(d)\epsilon(\frac{n}{d})} \\ 
+    =& \sum_{n|d}{g(d)\sum_{k|\frac{d}{n}}{\mu(k)}}
+    = \sum_{n|d}{g(d)\epsilon(\frac{d}{n})} \\ 
     =& g(n)
 \end{aligned}
 $$


### PR DESCRIPTION
数论莫比乌斯反演(倍数形式)的证明中,最后一步交换求和顺序时,下标出现了错误.
此commit对该处错误进行了修正.

这个错误并非由我发现,我最早在[link](https://github.com/OI-wiki/gitment/issues/56#issuecomment-836229635)看到了这个问题.  
感谢@sosupro

----------------------

**审核的同学** 请着重关注以下四方面：

1. 注意有没有 typo
2. 不论你是否熟悉相关知识，都请以初学者的角度把这个 PR 的内容阅读一遍，跟着作者的思路走，然后谈谈你的感受
3. 如果你熟悉相关知识，请按照自己的理解评估这个 PR 的内容是否合适
4. 请**尽量**保持跟进直到它被 merge 或 close

