### PR TITLE
fix mistakes in #3195 to update primitive-root.md

### DIFF
--- a/docs/math/primitive-root.md
+++ b/docs/math/primitive-root.md
@@ -111,7 +111,7 @@ $$
 由 $(ab)^{\delta_m(ab)}\equiv 1 \pmod m$ 可知
 
 $$
-1 \equiv (ab)^{\delta_m(ab)\delta_m(b)}\equiv a^{\delta_m(ab)} \pmod m
+1 \equiv (ab)^{\delta_m(ab)\delta_m(b)}\equiv a^{\delta_m(ab)\delta_m(b)} \pmod m
 $$
 
 故 $\delta_m(a)\mid\delta_m(ab)\delta_m(b)$。结合 $\gcd(\delta_m(a),\delta_m(b))=1$ 即得
@@ -232,7 +232,7 @@ $$
 
 所以若 $\gcd\big(k,\varphi(m)\big)=1$，则有：$\delta_m(g^k)=\varphi(m)$，即 $g^k$ 也是模 $m$ 的原根。
 
-而满足 $\gcd\big(\varphi(m),k\big)=1$ 且 $1<k<\varphi(m)$ 的 $k$ 有 $\varphi(\varphi(m))$ 个。所以原根就有 $\varphi(\varphi(m))$ 个。
+而满足 $\gcd\big(\varphi(m),k\big)=1$ 且 $1\leq k \leq \varphi(m)$ 的 $k$ 有 $\varphi(\varphi(m))$ 个。所以原根就有 $\varphi(\varphi(m))$ 个。
 
 **证毕**
 


### PR DESCRIPTION
close #3195 

性质3的充分性证明的第二行的末尾，应该是 $a^{\delta_m(ab)\delta_m(b)}$.
![image](https://user-images.githubusercontent.com/36043992/120101407-8b2ab400-c178-11eb-8af0-0f965aa55056.png)
类似的证明可以看https://www.cnblogs.com/ldysy2012/p/12208905.html 性质9
![image](https://user-images.githubusercontent.com/36043992/120101468-d6dd5d80-c178-11eb-9477-e360a7a70fe0.png)
原根个数证明的第四行，是 $1\leq k \leq \varphi(m)$
这个就是$1\leq k \leq \varphi(m)$中有$\varphi(\varphi(m))$个原根，由欧拉函数定义可证