### PR TITLE
修复了 pre 与 nxt 函数中没有检查是否存在前驱后继的问题

### DIFF
--- a/docs/ds/splay.md
+++ b/docs/ds/splay.md
@@ -191,7 +191,7 @@ int kth(int k) {
 int pre() {
   int cur = ch[rt][0];
   while (ch[cur][1]) cur = ch[cur][1];
-  splay(cur);
+  if (cur) splay(cur);
   return cur;
 }
 ```
@@ -204,7 +204,7 @@ int pre() {
 int nxt() {
   int cur = ch[rt][1];
   while (ch[cur][0]) cur = ch[cur][0];
-  splay(cur);
+  if (cur) splay(cur);
   return cur;
 }
 ```
@@ -353,13 +353,13 @@ struct Splay {
   int pre() {
     int cur = ch[rt][0];
     while (ch[cur][1]) cur = ch[cur][1];
-    splay(cur);
+    if (cur) splay(cur);
     return cur;
   }
   int nxt() {
     int cur = ch[rt][1];
     while (ch[cur][0]) cur = ch[cur][0];
-    splay(cur);
+    if (cur) splay(cur);
     return cur;
   }
   void del(int k) {

--- a/docs/ds/splay.md
+++ b/docs/ds/splay.md
@@ -190,7 +190,7 @@ int kth(int k) {
 ```cpp
 int pre() {
   int cur = ch[rt][0];
-  if (!cur) return cur; 
+  if (!cur) return cur;
   while (ch[cur][1]) cur = ch[cur][1];
   splay(cur);
   return cur;

--- a/docs/ds/splay.md
+++ b/docs/ds/splay.md
@@ -190,8 +190,9 @@ int kth(int k) {
 ```cpp
 int pre() {
   int cur = ch[rt][0];
+  if (!cur) return cur; 
   while (ch[cur][1]) cur = ch[cur][1];
-  if (cur) splay(cur);
+  splay(cur);
   return cur;
 }
 ```
@@ -203,8 +204,9 @@ int pre() {
 ```cpp
 int nxt() {
   int cur = ch[rt][1];
+  if (!cur) return cur;
   while (ch[cur][0]) cur = ch[cur][0];
-  if (cur) splay(cur);
+  splay(cur);
   return cur;
 }
 ```
@@ -352,14 +354,16 @@ struct Splay {
   }
   int pre() {
     int cur = ch[rt][0];
+    if (!cur) return cur;
     while (ch[cur][1]) cur = ch[cur][1];
-    if (cur) splay(cur);
+    splay(cur);
     return cur;
   }
   int nxt() {
     int cur = ch[rt][1];
+    if (!cur) return cur;
     while (ch[cur][0]) cur = ch[cur][0];
-    if (cur) splay(cur);
+    splay(cur);
     return cur;
   }
   void del(int k) {


### PR DESCRIPTION
虽然实际使用中常常先 ins 一个 inf 和一个 -inf，但是这里没有说明，那么是有可能出现不存在前驱/后继的情况的。此时如果无脑 Splay，在 Splay 函数中又是无脑设置根节点的话，会出现把 0 节点作为根节点，继而让整棵树子节点关系出错的情况。

<!--
首先，十分感谢你花时间来给 OI Wiki 开一个 Pull Request，下面是一些你可能需要知道的信息：

- 请在 commit 的时候写比较有意义的 commit message
- 请给 PR 起比较有意义的标题。
- 如果您的 PR 可以解决某个现有的 issue，请在这个文本框的开头部分写上 fix + issue 编号。 如：fix #1622
- 关于文档内容的基本格式和基本内容规范，可以查阅 [如何参与](https://oi-wiki.org/intro/htc)。
- 请确保勾选了下方允许维护者修改的候选框（lint bot 需要在 PR 环节修正格式）

**如果有需要额外注明的内容，请写在这个文本框的开头部分 :smile: 谢谢～**
-->

**审核的同学** 请着重关注以下四方面：

1. 注意有没有 typo
2. 不论你是否熟悉相关知识，都请以初学者的角度把这个 PR 的内容阅读一遍，跟着作者的思路走，然后谈谈你的感受
3. 如果你熟悉相关知识，请按照自己的理解评估这个 PR 的内容是否合适
4. 请**尽量**保持跟进直到它被 merge 或 close
