### PR TITLE
Revert "fix(math/quick-pow): initialize res to 1%mod in case exp=0 and mod=1"

### DIFF
--- a/docs/math/quick-pow.md
+++ b/docs/math/quick-pow.md
@@ -93,7 +93,7 @@ long long binpow(long long a, long long b) {
 ```cpp
 long long binpow(long long a, long long b, long long m) {
   a %= m;
-  long long res = 1 % m;
+  long long res = 1;
   while (b > 0) {
     if (b & 1) res = res * a % m;
     a = a * a % m;


### PR DESCRIPTION
Reverts OI-wiki/OI-wiki#3294

考虑到 mod 1 的情况没有现实意义，实践中几乎不会出现这种情况，因此撤回原 PR 的修改。