### PR TITLE
fix(math/quick-pow.md): 快速乘的代码实现中unsigned应改为unsigned long long类型

### DIFF
--- a/docs/math/quick-pow.md
+++ b/docs/math/quick-pow.md
@@ -250,7 +250,7 @@ $$
 ```cpp
 long long binmul(long long a, long long b, long long m) {
   unsigned long long c =
-      (unsigned long long)a * b - (unsigned)((long double)a / m * b + 0.5L) * m;
+      (unsigned long long)a * b - (unsigned long long)((long double)a / m * b + 0.5L) * m;
   if (c < m) return c;
   return c + m;
 }

--- a/docs/math/quick-pow.md
+++ b/docs/math/quick-pow.md
@@ -250,7 +250,8 @@ $$
 ```cpp
 long long binmul(long long a, long long b, long long m) {
   unsigned long long c =
-      (unsigned long long)a * b - (unsigned long long)((long double)a / m * b + 0.5L) * m;
+      (unsigned long long)a * b -
+      (unsigned long long)((long double)a / m * b + 0.5L) * m;
   if (c < m) return c;
   return c + m;
 }


### PR DESCRIPTION
修复了快速幂中快速乘的代码实现部分的一个细节

前文提到运用 unsigned long long 的自然溢出，但此处类型转换却转换为了 unsigned 类型，
在C++中，unsigned 是 32 位的，所以将此处的 unsigned 改为 64 位的 unsigned long long

如果不进行这样的更改的话，有 hack 数据 如：
```cpp
binmul(20436672733ll,20436672733ll,21993833369ll)
```
如果不进行这样的更改的话，函数返回值是 8916298685417424728 ，更改后得到正确值 3500622783

------

<!--
首先，十分感谢你花时间来给 OI Wiki 开一个 Pull Request，下面是一些你可能需要知道的信息：

- 请在 commit 的时候写比较有意义的 commit message
- 请给 PR 起比较有意义的标题。
- 如果您的 PR 可以解决某个现有的 issue，请在这个文本框的开头部分写上 fix + issue 编号。 如：fix #1622
- 关于文档内容的基本格式和基本内容规范，可以查阅 [如何参与](https://oi-wiki.org/intro/htc)。
- 请确保勾选了下方允许维护者修改的候选框（lint bot 需要在 PR 环节修正格式）

**如果有需要额外注明的内容，请写在这个文本框的开头部分 :smile: 谢谢～**
-->

**审核的同学** 请着重关注以下四方面：

1. 注意有没有 typo
2. 不论你是否熟悉相关知识，都请以初学者的角度把这个 PR 的内容阅读一遍，跟着作者的思路走，然后谈谈你的感受
3. 如果你熟悉相关知识，请按照自己的理解评估这个 PR 的内容是否合适
4. 请**尽量**保持跟进直到它被 merge 或 close
