### PR TITLE
fix(euler.md): 修正变量名不规范的问题

### DIFF
--- a/docs/math/number-theory/euler.md
+++ b/docs/math/number-theory/euler.md
@@ -28,7 +28,7 @@
     （根据定义可知）
 
 
--   由唯一分解定理，设 $n = \prod_{i=1}^{n}p_i^{k_i}$，其中 $p_i$ 是质数，有 $\varphi(n) = n \times \prod_{i = 1}^s{\dfrac{p_i - 1}{p_i}}$。
+-   由唯一分解定理，设 $n = \prod_{i=1}^{s}p_i^{k_i}$，其中 $p_i$ 是质数，有 $\varphi(n) = n \times \prod_{i = 1}^s{\dfrac{p_i - 1}{p_i}}$。
 
     证明：
 


### PR DESCRIPTION
euler.md 中一会是 $n$，一会是 $s$，上下文应统一。