### PR TITLE
fix(resources): remove `www.algomation.com`

### DIFF
--- a/docs/contest/resources.md
+++ b/docs/contest/resources.md
@@ -134,7 +134,6 @@ author: Suyun514, ChungZH, Enter-tainer, StudyingFather, Konano, JulieSigtuna, G
 ## 工具
 
 - [《100 个 gdb 小技巧》](https://github.com/hellogcc/100-gdb-tips)
-- [Algomation](http://www.algomation.com/)
 - [Algorithm Visualizer](http://algorithm-visualizer.org)
 - [cppreference](https://zh.cppreference.com/w/)：一个全面的 C 和 C++ 语言及其标准库的在线参考资料
 - [Compiler Explorer](https://godbolt.org)：在线查看编译后代码块对应的汇编语句，支持选择不同的编译器


### PR DESCRIPTION
此域名至少从20210414180310起就被赌博网站占据了，没有复原迹象，也没有搜到新域名。

参见：https://web.archive.org/web/20210414180310/https://www.algomation.com/

**审核的同学** 请着重关注以下四方面：

1. 注意有没有 typo
2. 不论你是否熟悉相关知识，都请以初学者的角度把这个 PR 的内容阅读一遍，跟着作者的思路走，然后谈谈你的感受
3. 如果你熟悉相关知识，请按照自己的理解评估这个 PR 的内容是否合适
4. 请**尽量**保持跟进直到它被 merge 或 close
