### PR TITLE
fix(单调队列优化动态规划推导公式错误):修复了单调栈页面的一个公式错误

### DIFF
--- a/docs/dp/opt/monotonous-queue-stack.md
+++ b/docs/dp/opt/monotonous-queue-stack.md
@@ -19,7 +19,7 @@ author: Marcythm, hsfzLZH1, Ir1d, greyqz, Anguei, billchenchina, Chrogeek, Chung
 
 由于 $\max$ 里出现了一个确定的常量 $b_i$，我们可以将它提到外面去。
 
-$f_{i,j}=\max\{f_{i-1,k}+b_i+|a_i-j|\}=\max\{f_{i-1,k}-|a_i-j|\}+b_i$
+$f_{i,j}=\max\{f_{i-1,k}+b_i-|a_i-j|\}=\max\{f_{i-1,k}-|a_i-j|\}+b_i$
 
 如果确定了 $i$ 和 $j$ 的值，那么 $|a_i-j|$ 的值也是确定的，也可以将这一部分提到外面去。
 


### PR DESCRIPTION
fix(单调队列优化动态规划):有个地方的推导-号写成+号
