### PR TITLE
fix(math/number-theory/gcd): correct exgcd Python version

### DIFF
--- a/docs/math/number-theory/gcd.md
+++ b/docs/math/number-theory/gcd.md
@@ -152,15 +152,11 @@ int Exgcd(int a, int b, int &x, int &y) {
 
 ```python
 # Python Version
-def Exgcd(a, b, x, y):
+def Exgcd(a, b):
     if b == 0:
-        x, y = 1, 0
-        return a
-    d = Exgcd(b, a % b, x, y)
-    t = x
-    x = y
-    y = t - (a // b) * y
-    return d
+        return a, 1, 0
+    d, x, y = Exgcd(b, a % b)
+    return d, y, x - (a // b) * y
 ```
 
 函数返回的值为 $\gcd$，在这个过程中计算 $x,y$ 即可。


### PR DESCRIPTION
Python 对于内建类型的函数传参是传值，原有的 exgcd 不会得到预期结果，因此将 x, y 加入返回值

<!--
首先，十分感谢你花时间来给 OI Wiki 开一个 Pull Request，下面是一些你可能需要知道的信息：

- 请在 commit 的时候写比较有意义的 commit message
- 请给 PR 起比较有意义的标题。
- 如果您的 PR 可以解决某个现有的 issue，请在这个文本框的开头部分写上 fix + issue 编号。 如：fix #1622
- 关于文档内容的基本格式和基本内容规范，可以查阅 [如何参与](https://oi-wiki.org/intro/htc)。
- 请确保勾选了下方允许维护者修改的候选框（lint bot 需要在 PR 环节修正格式）

**如果有需要额外注明的内容，请写在这个文本框的开头部分 :smile: 谢谢～**
-->

**审核的同学** 请着重关注以下四方面：

1. 注意有没有 typo
2. 不论你是否熟悉相关知识，都请以初学者的角度把这个 PR 的内容阅读一遍，跟着作者的思路走，然后谈谈你的感受
3. 如果你熟悉相关知识，请按照自己的理解评估这个 PR 的内容是否合适
4. 请**尽量**保持跟进直到它被 merge 或 close
