### PR TITLE
修复拉格朗日插值法第一种推导过程中线性同余方程组中的一处角标错误

### DIFF
--- a/docs/math/poly/lagrange.md
+++ b/docs/math/poly/lagrange.md
@@ -45,7 +45,7 @@ $$
 $$
 \begin{cases}
 f(x)\equiv y_1\pmod{(x-x_1)}\\
-f(x)\equiv y_n\pmod{(x-x_2)}\\
+f(x)\equiv y_2\pmod{(x-x_2)}\\
 \cdots\\
 f(x)\equiv y_n\pmod{(x-x_n)}
 \end{cases}


### PR DESCRIPTION
拉格朗日插值法中第一种推导过程中，关于 `f(x)` 的多项式线性同余方程组的第二个方程的角标错误，应当将 `f(x) ≡ y_n (mod f(x - x_2))` 改为 `f(x) ≡ y_2 (mod f(x - x_2)) `

<!--
首先，十分感谢你花时间来给 OI Wiki 开一个 Pull Request，下面是一些你可能需要知道的信息：

- 请在 commit 的时候写比较有意义的 commit message
- 请给 PR 起比较有意义的标题。
- 如果您的 PR 可以解决某个现有的 issue，请在这个文本框的开头部分写上 fix + issue 编号。 如：fix #1622
- 关于文档内容的基本格式和基本内容规范，可以查阅 [如何参与](https://oi-wiki.org/intro/htc)。
- 请确保勾选了下方允许维护者修改的候选框（lint bot 需要在 PR 环节修正格式）

**如果有需要额外注明的内容，请写在这个文本框的开头部分 :smile: 谢谢～**
-->

**审核的同学** 请着重关注以下四方面：

1. 注意有没有 typo
2. 不论你是否熟悉相关知识，都请以初学者的角度把这个 PR 的内容阅读一遍，跟着作者的思路走，然后谈谈你的感受
3. 如果你熟悉相关知识，请按照自己的理解评估这个 PR 的内容是否合适
4. 请**尽量**保持跟进直到它被 merge 或 close
