### PR TITLE
fix(string/kmp): erroneous python code snippet

### DIFF
--- a/docs/string/kmp.md
+++ b/docs/string/kmp.md
@@ -74,7 +74,7 @@ def prefix_function(s):
     pi = [0] * n
     for i in range(1, n):
         for j in range(i, -1, -1):
-            if s[0 : j] == s[i - j + 1, j]:
+            if s[0 : j] == s[i-j+1 : i+1]:
                 pi[i] = j
                 break
     return pi


### PR DESCRIPTION
前缀函数朴素算法的 python 代码在数组 slicing 时有错误。

**审核的同学** 请着重关注以下四方面：

1. 注意有没有 typo
2. 不论你是否熟悉相关知识，都请以初学者的角度把这个 PR 的内容阅读一遍，跟着作者的思路走，然后谈谈你的感受
3. 如果你熟悉相关知识，请按照自己的理解评估这个 PR 的内容是否合适
4. 请**尽量**保持跟进直到它被 merge 或 close
