### PR TITLE
fix: tweak size and vertical align of icons in page copyright

### DIFF
--- a/docs/_static/css/extra.css
+++ b/docs/_static/css/extra.css
@@ -11,6 +11,12 @@ blockquote.page-time{
   padding-left: 1.5rem;
   border-left: 5px solid #64b5f6; /* Just change the color value and that's it*/
 }
+blockquote.page-copyright i.md-icon {
+  display: inline-block;
+  transform: translateY(3.5px);
+  font-size: 0.9rem;
+  margin-right: 5px;
+}
 #myBtn {
     display: none;
     position: fixed; 


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/11341955/146774007-6ccb4b9f-bab1-44f9-b4f3-dc678badb622.png)

After:

![image](https://user-images.githubusercontent.com/11341955/146774090-6d604463-cda9-4f9f-9bfa-b3ee3e0b8d9e.png)
