### PR TITLE
fix: some mathjax resources not found when previewing with netlify

### DIFF
--- a/scripts/install_theme_vendor.sh
+++ b/scripts/install_theme_vendor.sh
@@ -18,7 +18,7 @@ echo "Downloading MathJax to $TEMP_DIR"
 echo "URL: $MATHJAX_URL"
 MATHJAX_REQUIRED_FILES=(
 	"config/TeX-MML-AM_CHTML.js"
-	"extensions/TeX"
+	"extensions"
 	"fonts/HTML-CSS/TeX/woff"
 	"jax/output/CommonHTML"
 	"jax/element"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11341955/148198485-57758515-d7c3-4b51-be64-956beb8962ff.png)
