### PR TITLE
fix(ci/pr-stale): disable for issues

### DIFF
--- a/.github/workflows/pr-stale.yml
+++ b/.github/workflows/pr-stale.yml
@@ -21,4 +21,6 @@ jobs:
           stale-pr-label: 'No Response / 失去响应'
           exempt-pr-labels: 'Busy Author / 作者正忙,Pending review / 等待审核,Pending merge / 等待合并,等待取消修改请求 / Pending Cancel Changes Request'
           days-before-pr-stale: 30
-          days-before-pr-close: 14 
+          days-before-pr-close: 14
+          days-before-issue-stale: -1
+          days-before-issue-close: -1


### PR DESCRIPTION
Upstream default settings is garbage, it enable for all by default.
