### PR TITLE
fix(build): disable `removeOptionalTags` in html-minifier

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,6 @@ gulp.task('minify:html', () => {
       minifyCSS: true,
       minifyURLs: true,
       removeComments: true,
-      removeOptionalTags: true,
       removeRedundantAttributes: true,
       removeStyleLinkTypeAttributes: true,
       removeScriptTypeAttributes: true,


### PR DESCRIPTION
参见 Telegram 群组讨论。