### PR TITLE
fix(math/number-theory/crt): 修正中国剩余定理代码中的模数

### DIFF
--- a/docs/math/number-theory/crt.md
+++ b/docs/math/number-theory/crt.md
@@ -44,9 +44,9 @@ LL CRT(int k, LL* a, LL* r) {
   for (int i = 1; i <= k; i++) {
     LL m = n / r[i], b, y;
     exgcd(m, r[i], b, y);  // b * m mod r[i] = 1
-    ans = (ans + a[i] * m * b % mod) % mod;
+    ans = (ans + a[i] * m * b % n) % n;
   }
-  return (ans % mod + mod) % mod;
+  return (ans % n + n) % n;
 }
 ```
 
@@ -61,8 +61,8 @@ def CRT(k, a, r):
     for i in range(1, k + 1):
         m = n // r[i]; b = y = 0
         exgcd(m, r[i], b, y) # b * m mod r[i] = 1
-        ans = (ans + a[i] * m * b % mod) % mod
-    return (ans % mod + mod) % mod
+        ans = (ans + a[i] * m * b % n) % n
+    return (ans % n + n) % n
 ```
 
 ## 算法的证明


### PR DESCRIPTION
中国剩余定理保证了在 n（方程组中所有模数的乘积）中有唯一解，这里其实并不需要一个额外的模数 mod，而是应该对 n 取模。