### PR TITLE
fix(geometry/nearest-points): 修改了归并排序中 STL 的应用

### DIFF
--- a/docs/geometry/nearest-points.md
+++ b/docs/geometry/nearest-points.md
@@ -117,7 +117,7 @@ $$
       int midx = a[m].x;
       rec(l, m), rec(m + 1, r);
       inplace_merge(a + l, a + m + 1, a + r + 1, &cmp_y);
-      
+    
       static pt t[MAXN];
       int tsz = 0;
       for (int i = l; i <= r; ++i)

--- a/docs/geometry/nearest-points.md
+++ b/docs/geometry/nearest-points.md
@@ -101,7 +101,7 @@ $$
 
 下面是递归本身：假设在调用前 `a[]` 已按 $x_i$ 排序。如果 $r-l$ 过小，使用暴力算法计算 $h$，终止递归。
 
-我们使用 `std::merge()` 来执行归并排序，并创建辅助缓冲区 `t[]`，$B$ 存储在其中。
+我们使用 `std::inplace_merge()` 来执行归并排序，并创建辅助缓冲区 `t[]`，$B$ 存储在其中。
 
 ???+note "主体函数"
     ```cpp
@@ -116,10 +116,9 @@ $$
       int m = (l + r) >> 1;
       int midx = a[m].x;
       rec(l, m), rec(m + 1, r);
+      inplace_merge(a + l, a + m + 1, a + r + 1, &cmp_y);
+      
       static pt t[MAXN];
-      merge(a + l, a + m + 1, a + m + 1, a + r + 1, t, &cmp_y);
-      copy(t, t + r - l + 1, a + l);
-    
       int tsz = 0;
       for (int i = l; i <= r; ++i)
         if (abs(a[i].x - midx) < mindist) {


### PR DESCRIPTION
修改了归并排序中 STL 的应用，将 std::merge() 变为 std::inplace_merge()，删掉 std::copy()，降低时间复杂度。