### PR TITLE
高斯消元里矩阵树定理的度数矩阵与邻接矩阵的加减顺序写反了

### DIFF
--- a/docs/math/gauss.md
+++ b/docs/math/gauss.md
@@ -304,25 +304,25 @@ cout << det;
 
 $$
 \begin{pmatrix}
-0 & 1 & 0 & 1 \\
-1 & 0 & 1 & 0 \\
-0 & 1 & 0 & 1 \\
-1 & 0 & 1 & 0 \end{pmatrix}-\begin{pmatrix}
 2 & 0 & 0 & 0 \\
 0 & 2 & 0 & 0 \\
 0 & 0 & 2 & 0 \\
-0 & 0 & 0 & 2 \end{pmatrix}=\begin{pmatrix}
--2 & 1 & 0 & 1 \\
-1 & -2 & 1 & 0 \\
-0 & 1 & -2 & 1 \\
-1 & 0 & 1 & -2 \end{pmatrix}
+0 & 0 & 0 & 2 \end{pmatrix}-\begin{pmatrix}
+0 & 1 & 0 & 1 \\
+1 & 0 & 1 & 0 \\
+0 & 1 & 0 & 1 \\
+1 & 0 & 1 & 0 \end{pmatrix}=\begin{pmatrix}
+2 & -1 & 0 & -1 \\
+-1 & 2 & -1 & 0 \\
+0 & -1 & 2 & -1 \\
+-1 & 0 & -1 & 2 \end{pmatrix}
 $$
 
 $$
 \begin{vmatrix}
--2 & 1 & 0 \\
-1 & -2 & 1 \\
-0 & 1 & -2 \end{vmatrix} = 4
+2 & -1 & 0 \\
+-1 & 2 & -1 \\
+0 & -1 & 2 \end{vmatrix} = 4
 $$
 
 可以用高斯消元解决，时间复杂度为 $O(n^3)$。


### PR DESCRIPTION
RT，应当是度数矩阵减邻接矩阵，下面行列式结果是对的但是正负号也都反了

<!--
首先，十分感谢您花时间来给 OI Wiki 开一个 Pull Request，下面是一些您可能需要知道的信息：

- 请在 Compare 页面仔细检查您的提交是否符合符合您的预期，例如您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
- 请在 commit 的时候写比较有意义的 commit message。
- 请给 PR 起比较有意义的标题。
- 如果您的 PR 可以解决某个现有的 issue，请在这个文本框的开头部分写上 fix + issue 编号。 如：fix #1622
- 关于文档内容的基本格式和基本内容规范，可以查阅 [如何参与](https://oi-wiki.org/intro/htc)。
- 请确保勾选了下方允许维护者修改的候选框（lint bot 需要在 PR 环节修正格式）

**如果有需要额外注明的内容，请写在这个文本框的开头部分 :smile: 谢谢～**
-->

**审核的同学** 请着重关注以下四方面：

1. 注意有没有 typo
2. 不论您是否熟悉相关知识，都请以初学者的角度把这个 PR 的内容阅读一遍，跟着作者的思路走，然后谈谈您的感受
3. 如果您熟悉相关知识，请按照自己的理解评估这个 PR 的内容是否合适
4. 请**尽量**保持跟进直到它被 merge 或 close
