### PR TITLE
fix(slope.md): 修正了题面的一个错误

### DIFF
--- a/docs/dp/opt/slope.md
+++ b/docs/dp/opt/slope.md
@@ -1,15 +1,15 @@
-author: Marcythm, hsfzLZH1, abc1763613206, greyqz, Ir1d, billchenchina, Chrogeek, Enter-tainer, StudyingFather, MrFoodinChina, luoguyuntianming, sshwy
+author: Marcythm, hsfzLZH1, abc1763613206, greyqz, Ir1d, billchenchina, Chrogeek, Enter-tainer, StudyingFather, MrFoodinChina, luoguyuntianming, sshwy, wood3
 
 ## 例题引入
 
 ???+note "[「HNOI2008」玩具装箱](https://loj.ac/problem/10188)"
-    有 $n$ 个玩具，第 $i$ 个玩具价值为 $c_i$。要求将这 $n$ 个玩具排成一排，分成若干段。对于一段 $[l,r]$，它的代价为 $(r-l+\sum_{i=L}^R c_i-L)^2$。求分段的最小代价。
+    有 $n$ 个玩具，第 $i$ 个玩具价值为 $c_i$。要求将这 $n$ 个玩具排成一排，分成若干段。对于一段 $[l,r]$，它的代价为 $(r-l+\sum_{i=l}^r c_i-L)^2$。其中 $L$ 是一个常量，求分段的最小代价。
     
-    $1\le n\le 5\times 10^4,1\le L,0\le c_i\le 10^7$。
+    $1\le n\le 5\times 10^4, 1\le L, c_i\le 10^7$。
 
 令 $f_i$ 表示前 $i$ 个物品，分若干段的最小代价。
 
-状态转移方程：$f_i=\min_{j<i}\{f_j+(pre_i-pre_j+i-j-1-L)^2\}$。
+状态转移方程：$f_i=\min_{j<i}\{f_j+(i-(j+1)+pre_i-pre_j-L)^2\}=\min_{j<i}\{f_j+(pre_i-pre_j+i-j-1-L)^2\}$。
 
 其中 $pre_i$ 表示前 $i$ 个数的和，即 $\sum_{j=1}^i c_j$。
 
@@ -63,9 +63,9 @@ $$
 在上述例题中，直线的斜率随 $i$ 单调变化，但是对于有些问题，斜率并不是单调的。这时我们需要维护凸包上的每一个节点，然后每次用当前的直线去切这个凸包。这个过程可以使用二分解决，因为凸包上相邻两个点的斜率是有单调性的。
 
 ???+note "玩具装箱 改"
-    有 $n$ 个玩具，第 $i$ 个玩具价值为 $c_i$。要求将这 $n$ 个玩具排成一排，分成若干段。对于一段 $[l,r]$，它的代价为 $(r-l+\sum_{i=L}^R c_i-L)^2$。求分段的最小代价。
+    有 $n$ 个玩具，第 $i$ 个玩具价值为 $c_i$。要求将这 $n$ 个玩具排成一排，分成若干段。对于一段 $[l,r]$，它的代价为 $(r-l+\sum_{i=l}^r c_i-L)^2$。其中 $L$ 是一个常量，求分段的最小代价。
     
-    $1\le n\le 5\times 10^4,1\le L,-10^7\le c_i\le 10^7$。
+    $1\le n\le 5\times 10^4,1\le L\le 10^7,-10^7\le c_i\le 10^7$。
 
 本题与「玩具装箱」问题唯一的区别是，玩具的价值可以为负。延续之前的思路，令 $f_i$ 表示前 $i$ 个物品，分若干段的最小代价。
 


### PR DESCRIPTION
根据[原题](https://loj.ac/p/10188)题面所述，$L$ 是一个常量，这里的简化题意中，求和符号用大写字母 $L,R$ 来对应区间显然不合适。
数据范围的部分就纯粹是抄写错误了，我按照原题修改好了。
顺手在后面推导的第一步加了一个更详细的中间步骤。

<!--
首先，十分感谢您花时间来给 OI Wiki 开一个 Pull Request，下面是一些您可能需要知道的信息：

- 请在 Compare 页面仔细检查您的提交是否符合符合您的预期，例如您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
- 请在 commit 的时候写比较有意义的 commit message。
- 请给 PR 起比较有意义的标题。
- 如果您的 PR 可以解决某个现有的 issue，请在这个文本框的开头部分写上 fix + issue 编号。 如：fix #1622
- 关于文档内容的基本格式和基本内容规范，可以查阅 [如何参与](https://oi-wiki.org/intro/htc)。
- 请确保勾选了下方允许维护者修改的候选框（lint bot 需要在 PR 环节修正格式）

**如果有需要额外注明的内容，请写在这个文本框的开头部分 :smile: 谢谢～**
-->

**审核的同学** 请着重关注以下四方面：

1. 注意有没有 typo
2. 不论您是否熟悉相关知识，都请以初学者的角度把这个 PR 的内容阅读一遍，跟着作者的思路走，然后谈谈您的感受
3. 如果您熟悉相关知识，请按照自己的理解评估这个 PR 的内容是否合适
4. 请**尽量**保持跟进直到它被 merge 或 close
