### PR TITLE
feat(scripts/post-build/math): remove unused client-side rendering scripts

### DIFF
--- a/scripts/post-build/math/task-handler.ts
+++ b/scripts/post-build/math/task-handler.ts
@@ -111,6 +111,10 @@ export const taskHandler = new (class implements TaskHandler<void> {
     const cssDestFile = path.join(siteDir, MATHJAX_TARGET_CSS_FILE);
     await fs.promises.mkdir(path.dirname(cssDestFile), { recursive: true });
     await fs.promises.writeFile(cssDestFile, renderer.getCSS(), "utf-8");
+
+    log("Remove client-side rendering assets");
+    await fs.promises.rm(path.join(siteDir, "_static/js/math-csr.js"));
+    await fs.promises.rm(path.join(siteDir, "assets/vendor/mathjax"), { recursive: true });
   }
 
   siteDir: string;


### PR DESCRIPTION
后端渲染 mathjax 之后前端就不需要这些文件了，删掉可以让部署更轻一点