### PR TITLE
ci: only add checks when pushing to master

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -2,6 +2,8 @@ name: Build LaTeX document
 
 on:
   push:
+    branches:
+      - master
   pull_request:
     branches:
       - master


### PR DESCRIPTION
when members contribute, the latex action checks twice.

<img width="722" alt="image" src="https://user-images.githubusercontent.com/64518651/180124133-e4752b91-d8f3-41a5-830e-bdec8480af09.png">
