### PR TITLE
fix(intro/docker-deploy, .bashrc, Dockerfile): 解决本地部署服务器时无法使用其他设备访问的问题

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -86,7 +86,7 @@ alias l='ls -CF'
 alias wiki-upd='export LC_ALL=C.UTF-8 && cd /OI-wiki && git pull origin master'
 alias wiki-theme='export LC_ALL=C.UTF-8 && cd /OI-wiki && ./scripts/pre-build/install-theme.sh'
 alias wiki-bld='export LC_ALL=C.UTF-8 && cd /OI-wiki && pipenv run mkdocs build -v'
-alias wiki-svr='export LC_ALL=C.UTF-8 && cd /OI-wiki && pipenv run mkdocs serve -v'
+alias wiki-svr='export LC_ALL=C.UTF-8 && cd /OI-wiki && pipenv run mkdocs serve -v -a ${LISTEN_IP}:${LISTEN_PORT}'
 alias wiki-bld-math='export LC_ALL=C.UTF-8 && cd /OI-wiki && pipenv run mkdocs build -v && env NODE_OPTIONS="--max_old_space_size=3072" yarn ts-node-esm ./scripts/post-build/math/render_math.ts'
 alias wiki-o='export LC_ALL=C.UTF-8 && cd /OI-wiki && yarn remark ./docs -o --silent'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM ubuntu:22.04
 
 LABEL org.oi-wiki.image.authors="frank99-xu@outlook.com mxr612@icloud.com coelacanthus@outlook.com"
 
+ENV LISTEN_IP ${LISTEN_IP:-0.0.0.0}
+ENV LISTEN_PORT ${LISTEN_PORT:-8000}
+
 WORKDIR /
 RUN apt-get update \
     && apt-get install -y git wget curl pipenv gcc g++ make \
@@ -17,5 +20,5 @@ RUN git clone ${WIKI_REPO:-https://github.com/OI-wiki/OI-wiki.git} --depth=1 \
 ADD .bashrc /root/
 
 WORKDIR /OI-wiki
-EXPOSE 8000
+EXPOSE ${LISTEN_PORT}
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,10 @@ FROM ubuntu:22.04
 
 LABEL org.oi-wiki.image.authors="frank99-xu@outlook.com mxr612@icloud.com coelacanthus@outlook.com"
 
-ENV LISTEN_IP ${LISTEN_IP:-0.0.0.0}
-ENV LISTEN_PORT ${LISTEN_PORT:-8000}
+ARG LISTEN_IP=0.0.0.0
+ARG LISTEN_PORT=8000
+ENV LISTEN_IP=${LISTEN_IP}
+ENV LISTEN_PORT=${LISTEN_PORT}
 
 WORKDIR /
 RUN apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,9 @@ FROM ubuntu:22.04
 
 LABEL org.oi-wiki.image.authors="frank99-xu@outlook.com mxr612@icloud.com coelacanthus@outlook.com"
 
-ARG LISTEN_IP=0.0.0.0
-ARG LISTEN_PORT=8000
-ENV LISTEN_IP=${LISTEN_IP}
-ENV LISTEN_PORT=${LISTEN_PORT}
+ARG WIKI_REPO PYPI_MIRROR LISTEN_IP LISTEN_PORT
+ENV LISTEN_IP=${LISTEN_IP:-0.0.0.0}
+ENV LISTEN_PORT=${LISTEN_PORT:-8000}
 
 WORKDIR /
 RUN apt-get update \

--- a/docs/intro/docker-deploy.md
+++ b/docs/intro/docker-deploy.md
@@ -22,6 +22,8 @@ docker pull ccr.ccs.tencentyun.com/oi-wiki/oi-wiki
 - 可以设置 `WIKI_REPO` 来使用 Wiki 仓库的镜像站点（当未设置时自动使用 GitHub）
 -   可以设置 `PYPI_MIRROR` 来使用 PyPI 仓库的镜像站点（当未设置时自动使用官方 PyPI）
     - 在国内建议使用 TUNA 镜像站 `https://pypi.tuna.tsinghua.edu.cn/simple/`
+- 可以设置 `LISTEN_IP` 来更改监听 IP（当未设置时为 `0.0.0.0` ，即监听所有 IP 的访问）
+- 可以设置 `LISTEN_PORT` 来更改监听端口（当未设置时为 `8000`）
 
 ## 运行容器
 

--- a/docs/intro/docker-deploy.md
+++ b/docs/intro/docker-deploy.md
@@ -17,6 +17,18 @@ docker pull ccr.ccs.tencentyun.com/oi-wiki/oi-wiki
 
 ## 自行构建镜像
 
+```bash
+# 以下命令在主机中运行
+# 克隆 Git 仓库
+git clone https://github.com/OI-wiki/OI-wiki.git
+cd OI-wiki/
+# 构建镜像
+docker build -t [name][:tag] . --build-arg [variable1]=[value1] [variable2]=[value2]...
+```
+
+- （必须）设置 `[name]` 以设置镜像名，（可选）设置 `[tag]` 以设置镜像标签（若设置，则运行时镜像名由两部分构成）。
+- 可以通过 `--build-arg` 参数设置环境变量。
+
 可以使用的环境变量：
 
 - 可以设置 `WIKI_REPO` 来使用 Wiki 仓库的镜像站点（当未设置时自动使用 GitHub）
@@ -24,6 +36,13 @@ docker pull ccr.ccs.tencentyun.com/oi-wiki/oi-wiki
     - 在国内建议使用 TUNA 镜像站 `https://pypi.tuna.tsinghua.edu.cn/simple/`
 - 可以设置 `LISTEN_IP` 来更改监听 IP（当未设置时为 `0.0.0.0` ，即监听所有 IP 的访问）
 - 可以设置 `LISTEN_PORT` 来更改监听端口（当未设置时为 `8000`）
+
+示例：
+
+```bash
+docker build -t OI_Wiki . --build-arg WIKI_REPO=https://hub.fastgit.xyz/OI-wiki/OI-wiki.git PYPI_MIRROR=https://pypi.tuna.tsinghua.edu.cn/simple/
+# 构建一个名为 OI_Wiki （标签默认）的镜像，使用 FastGit 服务加速克隆，使用 TUNA 镜像站。
+```
 
 ## 运行容器
 


### PR DESCRIPTION
fix #2181 中的容器外拒绝访问的问题。

通过修改mkdocs.yml配置文件，使 MkDocs 监听0.0.0.0，即包括但不限于本机的访问。

处于安全原因，我注释掉了这一行，并在 README “部署”章节中添加了打开方法。

Docker容器一般都需要取消这个注释，以在容器外正常访问，但容器内默认没有装 Vi 等文本编辑器。我在mkdocs.yml配置文件所在目录中创建了另一个修改好的文件，并修改Dockerfile，在构建容器时拷贝覆盖过去。