### PR TITLE
对原文中非旋 Treap 的完整代码中的错误进行修改并对 split_by_rk 函数进行重写

### DIFF
--- a/docs/ds/ett.md
+++ b/docs/ds/ett.md
@@ -206,7 +206,7 @@ void Delete(int u, int v) {
 
 点 $u$ 和点 $v$ 连通，当且仅当两个点属于同一棵树 $T$，即 $(u, u)$ 和 $(v, v)$ 属于 $\operatorname{ETR}(T)$，这可以根据点 $u$ 和点 $v$ 对应的 Treap 节点所在的 Treap 的根是否相同判断。
 
-### 例题 [P2147 \[SDOI2008\] 洞穴勘测](https://www.luogu.com.cn/problem/P2147)
+### 例题 [P2147\[SDOI2008\]洞穴勘测](https://www.luogu.com.cn/problem/P2147)
 
 维护连通性的模板题。
 

--- a/docs/ds/treap.md
+++ b/docs/ds/treap.md
@@ -393,7 +393,7 @@ pair<Node *, Node *> split(Node *cur, int key) {
 并且，此操作的递归部分和按值分裂也非常相似，这里不赘述。
 
 ```cpp
-tuple < Node*, Node*, Node* > split_by_rk(Node *cur, int rk) {
+tuple<Node *, Node *, Node *> split_by_rk(Node *cur, int rk) {
   if (cur == nullptr) return {nullptr, nullptr, nullptr};
   int ls_siz = cur->ch[0] == nullptr ? 0 : cur->ch[0]->siz;
   if (rk <= ls_siz) {
@@ -1059,27 +1059,27 @@ void print(Node* cur) {
         }
       }
     
-      tuple < Node*, Node*, Node* > split_by_rk(Node *cur, int rk) {
-    	if (cur == nullptr) return {nullptr, nullptr, nullptr};
-    	int ls_siz = cur->ch[0] == nullptr ? 0 : cur->ch[0]->siz;
-    	if (rk <= ls_siz) {
-    	  Node *l, *mid, *r;
-    	  tie(l, mid, r) = split_by_rk(cur->ch[0], rk);
-    	  cur->ch[0] = r;
-    	  cur->upd_siz();
-    	  return {l, mid, cur};
-    	} else if (rk <= ls_siz + cur->cnt) {
-    	  Node *lt = cur->ch[0];
-    	  Node *rt = cur->ch[1];
-    	  cur->ch[0] = cur->ch[1] = nullptr;
-    	  return {lt, cur, rt};
-    	} else {
-    	  Node *l, *mid, *r;
-    	  tie(l, mid, r) = split_by_rk(cur->ch[1], rk - ls_siz - cur->cnt);
-    	  cur->ch[1] = l;
-    	  cur->upd_siz();
-    	  return {cur, mid, r};
-    	}
+      tuple<Node *, Node *, Node *> split_by_rk(Node *cur, int rk) {
+        if (cur == nullptr) return {nullptr, nullptr, nullptr};
+        int ls_siz = cur->ch[0] == nullptr ? 0 : cur->ch[0]->siz;
+        if (rk <= ls_siz) {
+          Node *l, *mid, *r;
+          tie(l, mid, r) = split_by_rk(cur->ch[0], rk);
+          cur->ch[0] = r;
+          cur->upd_siz();
+          return {l, mid, cur};
+        } else if (rk <= ls_siz + cur->cnt) {
+          Node *lt = cur->ch[0];
+          Node *rt = cur->ch[1];
+          cur->ch[0] = cur->ch[1] = nullptr;
+          return {lt, cur, rt};
+        } else {
+          Node *l, *mid, *r;
+          tie(l, mid, r) = split_by_rk(cur->ch[1], rk - ls_siz - cur->cnt);
+          cur->ch[1] = l;
+          cur->upd_siz();
+          return {cur, mid, r};
+        }
       }
     
       Node *merge(Node *u, Node *v) {
@@ -1153,7 +1153,7 @@ void print(Node* cur) {
     
       int qnex(int val) {
         auto temp = split(root, val);
-    	int ret = qval_by_rank(temp.second, 1);
+        int ret = qval_by_rank(temp.second, 1);
         root = merge(temp.first, temp.second);
         return ret;
       }

--- a/docs/ds/treap.md
+++ b/docs/ds/treap.md
@@ -393,33 +393,32 @@ pair<Node *, Node *> split(Node *cur, int key) {
 并且，此操作的递归部分和按值分裂也非常相似，这里不赘述。
 
 ```cpp
-#define _3 second.second
-#define _2 second.first
-
-pair<Node *, pair<Node *, Node *>> split_by_rk(Node *cur, int rk) {
-  if (cur == nullptr) return {nullptr, {nullptr, nullptr}};
+tuple < Node*, Node*, Node* > split_by_rk(Node *cur, int rk) {
+  if (cur == nullptr) return {nullptr, nullptr, nullptr};
   int ls_siz = cur->ch[0] == nullptr ? 0 : cur->ch[0]->siz;
   if (rk <= ls_siz) {
     // 排名和 cur 相等的节点在左子树
-    auto temp = split_by_rk(cur->ch[0], rk);
-    cur->ch[0] = temp._3;  // 返回的第三个 treap 中的排名都大于 rk
-    // cur 的左子树被设成 temp._3 后，整个 cur 中节点的排名都大于 rk
+    Node *l, *mid, *r;
+    tie(l, mid, r) = split_by_rk(cur->ch[0], rk);
+    cur->ch[0] = r;  // 返回的第三个 treap 中的排名都大于 rk
+    // cur 的左子树被设成 r 后，整个 cur 中节点的排名都大于 rk
     cur->upd_siz();
-    return {temp.first, {temp._2, cur}};
+    return {l, mid, cur};
   } else if (rk <= ls_siz + cur->cnt) {
     // 和 cur 相等的就是当前节点
     Node *lt = cur->ch[0];
     Node *rt = cur->ch[1];
     cur->ch[0] = cur->ch[1] = nullptr;
     // 分裂后第二个 treap 只有一个节点，所有要把它的子树设置为空
-    return {lt, {cur, rt}};
+    return {lt, cur, rt};
   } else {
     // 排名和 cur 相等的节点在右子树
     // 递归过程同上
-    auto temp = split_by_rk(cur->ch[1], rk - ls_siz - cur->cnt);
-    cur->ch[1] = temp.first;
+    Node *l, *mid, *r;
+    tie(l, mid, r) = split_by_rk(cur->ch[1], rk - ls_siz - cur->cnt);
+    cur->ch[1] = l;
     cur->upd_siz();
-    return {cur, {temp._2, temp._3}};
+    return {cur, mid, r};
   }
 }
 ```
@@ -567,9 +566,10 @@ int qrank_by_val(Node* cur, int val) {
 
 ```cpp
 int qval_by_rank(Node *cur, int rk) {
-  auto temp = split_by_rk(cur, rk);
-  int ret = temp._2->val;
-  root = merge(temp.first, merge(temp._2, temp._3));
+  Node *l, *mid, *r;
+  tie(l, mid, r) = split_by_rk(cur, rk);
+  int ret = mid->val;
+  root = merge(merge(l, mid), r);
   return ret;
 }
 ```
@@ -1059,25 +1059,27 @@ void print(Node* cur) {
         }
       }
     
-      pair<Node *, pair<Node *, Node *>> split_by_rk(Node *cur, int rk) {
-        if (cur == nullptr) return {nullptr, {nullptr, nullptr}};
-        int ls_siz = cur->ch[0] == nullptr ? 0 : cur->ch[0]->siz;
-        if (rk <= ls_siz) {
-          auto temp = split_by_rk(cur->ch[0], rk);
-          cur->ch[0] = temp._3;
-          cur->upd_siz();
-          return {temp.first, {temp._2, cur}};
-        } else if (rk <= ls_siz + cur->cnt) {
-          Node *lt = cur->ch[0];
-          Node *rt = cur->ch[1];
-          cur->ch[0] = cur->ch[1] = nullptr;
-          return {lt, {cur, rt}};
-        } else {
-          auto temp = split_by_rk(cur->ch[1], rk - ls_siz - cur->cnt);
-          cur->ch[1] = temp.first;
-          cur->upd_siz();
-          return {cur, {temp._2, temp._3}};
-        }
+      tuple < Node*, Node*, Node* > split_by_rk(Node *cur, int rk) {
+    	if (cur == nullptr) return {nullptr, nullptr, nullptr};
+    	int ls_siz = cur->ch[0] == nullptr ? 0 : cur->ch[0]->siz;
+    	if (rk <= ls_siz) {
+    	  Node *l, *mid, *r;
+    	  tie(l, mid, r) = split_by_rk(cur->ch[0], rk);
+    	  cur->ch[0] = r;
+    	  cur->upd_siz();
+    	  return {l, mid, cur};
+    	} else if (rk <= ls_siz + cur->cnt) {
+    	  Node *lt = cur->ch[0];
+    	  Node *rt = cur->ch[1];
+    	  cur->ch[0] = cur->ch[1] = nullptr;
+    	  return {lt, cur, rt};
+    	} else {
+    	  Node *l, *mid, *r;
+    	  tie(l, mid, r) = split_by_rk(cur->ch[1], rk - ls_siz - cur->cnt);
+    	  cur->ch[1] = l;
+    	  cur->upd_siz();
+    	  return {cur, mid, r};
+    	}
       }
     
       Node *merge(Node *u, Node *v) {
@@ -1135,9 +1137,10 @@ void print(Node* cur) {
       }
     
       int qval_by_rank(Node *cur, int rk) {
-        auto temp = split_by_rk(cur, rk);
-        int ret = temp._2->val;
-        root = merge(temp.first, merge(temp._2, temp._3));
+        Node *l, *mid, *r;
+        tie(l, mid, r) = split_by_rk(cur, rk);
+        int ret = mid->val;
+        root = merge(merge(l, mid), r);
         return ret;
       }
     
@@ -1150,6 +1153,7 @@ void print(Node* cur) {
     
       int qnex(int val) {
         auto temp = split(root, val);
+    	int ret = qval_by_rank(temp.second, 1);
         root = merge(temp.first, temp.second);
         return ret;
       }


### PR DESCRIPTION
原文中非旋 Treap 完整代码中的 qnex 函数 漏加了 int ret = qval_by_rank(temp.second, 1); 一句，会导致CE，进行了修改。
对于非旋 Treap 中 split_by_rk 的返回值，写成 tuple 的形式并用 tie 接受返回值显然更加直观且便捷。

- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->
