### PR TITLE
fix(steiner-tree): 删除多余空格

### DIFF
--- a/docs/graph/steiner-tree.md
+++ b/docs/graph/steiner-tree.md
@@ -48,7 +48,7 @@
 
 ??? note "参考实现"
     ```cpp
-      --8<-- "docs/graph/code/steiner-tree/steiner-tree_1.cpp"
+    --8<-- "docs/graph/code/steiner-tree/steiner-tree_1.cpp"
     ```
 
 另外一道经典例题 [\[WC2008\]游览计划](https://www.luogu.com.cn/problem/P4294)。
@@ -67,15 +67,12 @@
 
 ??? note "参考实现"
     ```cpp
-      --8<-- "docs/graph/code/steiner-tree/steiner-tree_2.cpp"
+    --8<-- "docs/graph/code/steiner-tree/steiner-tree_2.cpp"
     ```
 
 ## 习题
 
-[【模板】最小斯坦纳树](https://www.luogu.com.cn/problem/P6192)
-
-[\[WC2008\]游览计划](https://www.luogu.com.cn/problem/P4294)
-
-[\[JLOI2015\]管道连接](https://loj.ac/problem/2110)
-
-[\[APIO2013\]机器人](https://www.luogu.com.cn/problem/P3638)
+- [【模板】最小斯坦纳树](https://www.luogu.com.cn/problem/P6192)
+- [\[WC2008\]游览计划](https://www.luogu.com.cn/problem/P4294)
+- [\[JLOI2015\]管道连接](https://loj.ac/problem/2110)
+- [\[APIO2013\]机器人](https://www.luogu.com.cn/problem/P3638)


### PR DESCRIPTION
- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

目前每行代码前面都会多两个空格。，

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->

