### PR TITLE
更新关于 Tarjan 离线 LCA 算法的说明

### DIFF
--- a/docs/graph/lca.md
+++ b/docs/graph/lca.md
@@ -148,9 +148,13 @@
 
 #### 性质
 
-Tarjan 算法需要初始化并查集，所以预处理的时间复杂度为 $O(n)$，Tarjan 算法处理所有 $m$ 次询问的时间复杂度为 $O(n + m)$。但是 Tarjan 算法的常数比倍增算法大。
+Tarjan 算法需要初始化并查集，所以预处理的时间复杂度为 $O(n)$。
 
-需要注意的是，Tarjan 算法中使用的并查集性质比较特殊，在仅使用路径压缩优化的情况下，单次调用 `find()` 函数的时间复杂度为均摊 $O(1)$，而不是 $O(\log n)$。具体可以见 [并查集部分的引用：A Linear-Time Algorithm for a Special Case of Disjoint Set Union](../ds/dsu.md#references)。
+朴素的 Tarjan 算法处理所有 $m$ 次询问的时间复杂度为 $O(m + \alpha(m+n, n) + n)$，。但是 Tarjan 算法的常数比倍增算法大。存在 $O(m + n)$ 的实现。
+
+~~需要注意的是，Tarjan 算法中使用的并查集性质比较特殊，在仅使用路径压缩优化的情况下，单次调用 `find()` 函数的时间复杂度为均摊 $\sout{O(1)}$，而不是 $\sout{O(\log n)}$。具体可以见 [并查集部分的引用：A Linear-Time Algorithm for a Special Case of Disjoint Set Union](../ds/dsu.md#references)。~~
+
+**注意：以下的朴素 Tarjan 实现复杂度为 $O(m + \alpha(m+n, n) + n)$。如果需要追求严格线性，可以参考 [Gabow 和 Tarjan 于 1983 年的论文](https://dl.acm.org/doi/pdf/10.1145/800061.808753 )。其中给出了一种复杂度为 $O(m + n)$ 的方法。**
 
 #### 实现
 


### PR DESCRIPTION
事实上在 [wcipeg 界面](http://wcipeg.com/wiki/Lowest_common_ancestor) 和原论文中都有提到 Tarjan LCA 的复杂度是需要带只 $\alpha$ 的，严格线性需要更多 tech。但是残念，之前的编辑者~~大概是只读了论文标题~~认为此处 dsu 的复杂度为均摊 $O(1)$，我并没有找到这种说法的依据。

- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->
