### PR TITLE
fix(lca): 统一文字描述和代码实现

### DIFF
--- a/docs/graph/lca.md
+++ b/docs/graph/lca.md
@@ -279,16 +279,14 @@ Tarjan 算法需要初始化并查集，所以预处理的时间复杂度为 $O(
 
 ???+note "参考代码"
     ```cpp
-    int dfn[N << 1], dep[N << 1], dfntot = 0;
+    int dfn[N << 1], pos[N << 1], dfntot = 0;
     
-    void dfs(int t, int depth) {
+    void dfs(int t) {
       dfn[++dfntot] = t;
       pos[t] = dfntot;
-      dep[dfntot] = depth;
       for (int i = head[t]; i; i = side[i].next) {
-        dfs(side[i].to, depth + 1);
+        dfs(side[i].to);
         dfn[++dfntot] = t;
-        dep[dfntot] = depth;
       }
     }
     
@@ -298,7 +296,7 @@ Tarjan 算法需要初始化并查集，所以预处理的时间复杂度为 $O(
       for (int i = 1; i <= (N << 1) - 1; ++i) st[0][i] = dfn[i];
       for (int i = 1; i <= lg[(N << 1) - 1]; ++i)
         for (int j = 1; j + (1 << i) - 1 <= ((N << 1) - 1); ++j)
-            st[i][j] = dep[st[i - 1][j]] < dep[st[i - 1][j + (1 << i - 1)]
+            st[i][j] = pos[st[i - 1][j]] < pos[st[i - 1][j + (1 << i - 1)]
                             ? st[i - 1][j]
                             : st[i - 1][j + (1 << i - 1)];
     }

--- a/docs/graph/lca.md
+++ b/docs/graph/lca.md
@@ -279,7 +279,7 @@ Tarjan 算法需要初始化并查集，所以预处理的时间复杂度为 $O(
 
 ???+note "参考代码"
     ```cpp
-    int dfn[N << 1], pos[N << 1], dfntot = 0;
+    int dfn[N << 1], pos[N], dfntot = 0;
     
     void dfs(int t) {
       dfn[++dfntot] = t;


### PR DESCRIPTION
- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

将代码修改为了和文字描述对应的实现

rvalue | SIGHIBR, [2022/11/6 23:39]
式子没错

rvalue | SIGHIBR, [2022/11/6 23:39]
然后和代码并不对应

rvalue | SIGHIBR, [2022/11/6 23:40]
代码是另一种写法

rvalue | SIGHIBR, [2022/11/6 23:41]
那看来就只是代码和式子脱节了(
