### PR TITLE
fix: 解决部分代码因变量/数组名与 C++ 17 关键字冲突而导致编译错误的问题

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,16 @@ on:
   push:
     branches:
       - master
+    paths:
+      - '**.cpp'
+      - '/scripts/test.py'
   pull_request:
     branches:
       - master
+    paths:
+      - '**.cpp'
+      - '/scripts/test.py'
+  workflow_dispatch:
 
 jobs:
   test:

--- a/docs/dp/code/dynamic/dynamic_1.cpp
+++ b/docs/dp/code/dynamic/dynamic_1.cpp
@@ -1,5 +1,4 @@
 #include <bits/stdc++.h>
-
 using namespace std;
 
 typedef long long LL;
@@ -8,7 +7,7 @@ const int maxn = 500010;
 const int INF = 0x3f3f3f3f;
 
 int Begin[maxn], Next[maxn], To[maxn], e, n, m;
-int size[maxn], son[maxn], top[maxn], fa[maxn], dis[maxn], p[maxn], id[maxn],
+int sz[maxn], son[maxn], top[maxn], fa[maxn], dis[maxn], p[maxn], id[maxn],
     End[maxn];
 // p[i]表示i树剖后的编号，id[p[i]] = i
 int cnt, tot, a[maxn], f[maxn][2];
@@ -94,7 +93,7 @@ inline void add(int u, int v) {
 }
 
 inline void DFS1(int u) {
-  size[u] = 1;
+  sz[u] = 1;
   int Max = 0;
   f[u][1] = a[u];
   for (int i = Begin[u]; i; i = Next[i]) {
@@ -103,9 +102,9 @@ inline void DFS1(int u) {
     dis[v] = dis[u] + 1;
     fa[v] = u;
     DFS1(v);
-    size[u] += size[v];
-    if (size[v] > Max) {
-      Max = size[v];
+    sz[u] += sz[v];
+    if (sz[v] > Max) {
+      Max = sz[v];
       son[u] = v;
     }
     f[u][1] += f[v][0];

--- a/docs/dp/code/tree/tree_3.cpp
+++ b/docs/dp/code/tree/tree_3.cpp
@@ -1,9 +1,8 @@
 #include <bits/stdc++.h>
-
 using namespace std;
 
 int head[1000010 << 1], tot;
-long long n, size[1000010], dep[1000010];
+long long n, sz[1000010], dep[1000010];
 long long f[1000010];
 
 struct node {
@@ -11,18 +10,18 @@ struct node {
 } e[1000010 << 1];
 
 void add(int u, int v) {  // 建图
-  e[++tot] = node{v, head[u]};
+  e[++tot] = {v, head[u]};
   head[u] = tot;
 }
 
 void dfs(int u, int fa) {  // 预处理dfs
-  size[u] = 1;
+  sz[u] = 1;
   dep[u] = dep[fa] + 1;
   for (int i = head[u]; i; i = e[i].next) {
     int v = e[i].to;
     if (v != fa) {
       dfs(v, u);
-      size[u] += size[v];
+      sz[u] += sz[v];
     }
   }
 }
@@ -31,7 +30,7 @@ void get_ans(int u, int fa) {  // 第二次dfs换根dp
   for (int i = head[u]; i; i = e[i].next) {
     int v = e[i].to;
     if (v != fa) {
-      f[v] = f[u] - size[v] * 2 + n;
+      f[v] = f[u] - sz[v] * 2 + n;
       get_ans(v, u);
     }
   }
@@ -41,7 +40,7 @@ int main() {
   scanf("%lld", &n);
   int u, v;
   for (int i = 1; i <= n - 1; i++) {
-    scanf("%d %d", &u, &v);
+    scanf("%d%d", &u, &v);
     add(u, v);
     add(v, u);
   }

--- a/docs/ds/code/treap/treap_1.cpp
+++ b/docs/ds/code/treap/treap_1.cpp
@@ -8,16 +8,16 @@
 int n;
 
 struct treap {  // 直接维护成数据结构，可以直接用
-  int l[maxn], r[maxn], val[maxn], rnd[maxn], size[maxn], w[maxn];
+  int l[maxn], r[maxn], val[maxn], rnd[maxn], size_[maxn], w[maxn];
   int sz, ans, rt;
 
-  inline void pushup(int x) { size[x] = size[l[x]] + size[r[x]] + w[x]; }
+  inline void pushup(int x) { size_[x] = size_[l[x]] + size_[r[x]] + w[x]; }
 
   void lrotate(int &k) {
     int t = r[k];
     r[k] = l[t];
     l[t] = k;
-    size[t] = size[k];
+    size_[t] = size_[k];
     pushup(k);
     k = t;
   }
@@ -26,7 +26,7 @@ struct treap {  // 直接维护成数据结构，可以直接用
     int t = l[k];
     l[k] = r[t];
     r[t] = k;
-    size[t] = size[k];
+    size_[t] = size_[k];
     pushup(k);
     k = t;
   }
@@ -35,13 +35,13 @@ struct treap {  // 直接维护成数据结构，可以直接用
     if (!k) {
       sz++;
       k = sz;
-      size[k] = 1;
+      size_[k] = 1;
       w[k] = 1;
       val[k] = x;
       rnd[k] = rand();
       return;
     }
-    size[k]++;
+    size_[k]++;
     if (val[k] == x) {
       w[k]++;
     } else if (val[k] < x) {
@@ -58,7 +58,7 @@ struct treap {  // 直接维护成数据结构，可以直接用
     if (val[k] == x) {
       if (w[k] > 1) {
         w[k]--;
-        size[k]--;
+        size_[k]--;
         return true;
       }
       if (l[k] == 0 || r[k] == 0) {
@@ -73,11 +73,11 @@ struct treap {  // 直接维护成数据结构，可以直接用
       }
     } else if (val[k] < x) {
       bool succ = del(r[k], x);
-      if (succ) size[k]--;
+      if (succ) size_[k]--;
       return succ;
     } else {
       bool succ = del(l[k], x);
-      if (succ) size[k]--;
+      if (succ) size_[k]--;
       return succ;
     }
   }
@@ -85,19 +85,19 @@ struct treap {  // 直接维护成数据结构，可以直接用
   int queryrank(int k, int x) {
     if (!k) return 0;
     if (val[k] == x)
-      return size[l[k]] + 1;
+      return size_[l[k]] + 1;
     else if (x > val[k]) {
-      return size[l[k]] + w[k] + queryrank(r[k], x);
+      return size_[l[k]] + w[k] + queryrank(r[k], x);
     } else
       return queryrank(l[k], x);
   }
 
   int querynum(int k, int x) {
     if (!k) return 0;
-    if (x <= size[l[k]])
+    if (x <= size_[l[k]])
       return querynum(l[k], x);
-    else if (x > size[l[k]] + w[k])
-      return querynum(r[k], x - size[l[k]] - w[k]);
+    else if (x > size_[l[k]] + w[k])
+      return querynum(r[k], x - size_[l[k]] - w[k]);
     else
       return val[k];
   }

--- a/docs/math/code/quick-pow/quick-pow_1.cpp
+++ b/docs/math/code/quick-pow/quick-pow_1.cpp
@@ -2,7 +2,7 @@
 using namespace std;
 int a[505], b[505], t[505], i, j;
 
-int mult(int x[], int y[])  // 高精度乘法
+void mult(int x[], int y[])  // 高精度乘法
 {
   memset(t, 0, sizeof(t));
   for (i = 1; i <= x[0]; i++) {

--- a/docs/misc/code/cdq-divide/cdq-divide_2.cpp
+++ b/docs/misc/code/cdq-divide/cdq-divide_2.cpp
@@ -24,7 +24,7 @@ struct treearray {
   }
 } ta;
 
-struct data {
+struct data_ {
   int val;
   int del;
   int ans;
@@ -33,11 +33,11 @@ struct data {
 int rv[100010];
 ll res;
 
-bool cmp1(const data& a, const data& b) {
+bool cmp1(const data_& a, const data_& b) {
   return a.val < b.val;
 }  // 重写两个比较
 
-bool cmp2(const data& a, const data& b) { return a.del < b.del; }
+bool cmp2(const data_& a, const data_& b) { return a.del < b.del; }
 
 void solve(int l, int r) {  // 底下是具体的式子，套用
   if (r - l == 1) {

--- a/docs/misc/code/cdq-divide/cdq-divide_3.cpp
+++ b/docs/misc/code/cdq-divide/cdq-divide_3.cpp
@@ -6,7 +6,7 @@ using namespace std;
 typedef double db;
 const int N = 1e6 + 10;
 
-struct data {
+struct data_ {
   int h;
   int v;
   int p;
@@ -18,28 +18,28 @@ int n;
 bool tr;
 
 // 底下是重写比较
-inline bool cmp1(const data& a, const data& b) {
+inline bool cmp1(const data_& a, const data_& b) {
   if (tr)
     return a.h > b.h;
   else
     return a.h < b.h;
 }
 
-inline bool cmp2(const data& a, const data& b) {
+inline bool cmp2(const data_& a, const data_& b) {
   if (tr)
     return a.v > b.v;
   else
     return a.v < b.v;
 }
 
-inline bool cmp3(const data& a, const data& b) {
+inline bool cmp3(const data_& a, const data_& b) {
   if (tr)
     return a.p < b.p;
   else
     return a.p > b.p;
 }
 
-inline bool cmp4(const data& a, const data& b) { return a.v == b.v; }
+inline bool cmp4(const data_& a, const data_& b) { return a.v == b.v; }
 
 struct treearray {
   int ma[2 * N];

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -31,7 +31,7 @@ for line in lines:
         print(cpp + ' test skipped')
         continue
 
-    cmd = 'g++ -std=c++14 '+cpp+' -o '+name
+    cmd = 'g++ -std=c++17 '+cpp+' -o '+name
     # 判断CE
     if os.system(cmd) == 0:
         print(cpp+' Successfully compiled')


### PR DESCRIPTION
### 承诺

- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

----

### 修改说明

- `.github/workflows/test.yml`：仅在 C++ 文件、`/scripts/test.py` 修改时执行测试，不进行不必要的 GitHub Actions 工作流。
- `docs/dp/code/dynamic/dynamic_1.cpp`、`docs/dp/code/tree/tree_3.cpp`、`docs/ds/code/treap/treap_1.cpp`、`docs/math/code/quick-pow/quick-pow_1.cpp`、`docs/misc/code/cdq-divide/cdq-divide_2.cpp`、`docs/misc/code/cdq-divide/cdq-divide_3.cpp`：解决 C++ 17 不兼容而编译错误的问题。
- `scripts/test.py`：设定编译参数为 `g++ -std=c++17 cppfile.cpp -o cppfile`，防止未来默认的 C++ 为更高版本而再次造成编译错误等问题。

> **Note**
> 尽管所有代码都可以正常编译、运行、通过评测，但没有解决 ISO C++ 17 中新产生的一些警告。

----

### 其它

原拉取请求：#4486 

运行结果：https://github.com/yusancky/OI-wiki/actions/runs/3692314693 ／ https://github.com/OI-wiki/OI-wiki/actions/runs/3692408735/jobs/6251276110