### PR TITLE
feat(sieve.md): 线性筛代码及注释的问题

### DIFF
--- a/docs/math/number-theory/sieve.md
+++ b/docs/math/number-theory/sieve.md
@@ -198,18 +198,18 @@ author: inkydragon, TravorLZH, YOYO-UIAT, wood3, shuzhouliu
     
         ```cpp
         void init() {
-          for (int i = 2; i < MAXN; ++i) {
+          for (int i = 2; i <= MAXN; ++i) {
             if (!vis[i]) {
               pri[cnt++] = i;
             }
             for (int j = 0; j < cnt; ++j) {
-              if (1ll * i * pri[j] >= MAXN) break;
+              if (1ll * i * pri[j] > MAXN) break;
               vis[i * pri[j]] = 1;
               if (i % pri[j] == 0) {
                 // i % pri[j] == 0
                 // 换言之，i 之前被 pri[j] 筛过了
-                // 由于 pri 里面质数是从小到大的，所以 i 乘上其他的质数的结果一定也是
-                // pri[j] 的倍数 它们都被筛过了，就不需要再筛了，所以这里直接 break
+                // 由于 pri 里面质数是从小到大的，所以 i 乘上其他的质数的结果一定会被
+                // pri[j]的倍数筛掉，就不需要在这里先筛一次，所以这里直接 break
                 // 掉就好了
                 break;
               }
@@ -234,8 +234,8 @@ author: inkydragon, TravorLZH, YOYO-UIAT, wood3, shuzhouliu
                         """
                         i % pri[j] == 0
                         换言之，i 之前被 pri[j] 筛过了
-                        由于 pri 里面质数是从小到大的，所以 i 乘上其他的质数的结果一定也是
-                        pri[j] 的倍数 它们都被筛过了，就不需要再筛了，所以这里直接 break
+                        由于 pri 里面质数是从小到大的，所以 i 乘上其他的质数的结果一定也会
+                        被pri[j]的倍数筛掉，就不需要在这里先筛一次，所以这里直接 break
                         掉就好了
                         """
                         break


### PR DESCRIPTION
- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->
修复了线性筛代码与前面说的歧义，前面说的是`2-MAXN`
#### 可代码中是`2-MAXN - 1`
#### 还有注释的问题，跟算法实现不符合