### PR TITLE
fix(python.md): 修正“类型标注”中示例代码未正确显示的错误

### DIFF
--- a/docs/lang/python.md
+++ b/docs/lang/python.md
@@ -727,7 +727,7 @@ NameError: name 'nothing' is not defined
 
 >>> __annotations__
 {'nothing': <class 'str'>}
-````
+```
 
 ## 装饰器
 

--- a/docs/lang/python.md
+++ b/docs/lang/python.md
@@ -706,6 +706,7 @@ TypeError: unsupported operand type(s) for +: 'int' and 'str'
 
 Python 3.5 后引入了类型标注，允许设置函数参数和返回值的类型，但只是作为提示，并没有实际的限制作用，需要静态检查工具才能排除这类错误（例如 [PyCharm](https://www.jetbrains.com/pycharm/) 和 [Mypy](http://mypy-lang.org/)），所以显得有些鸡肋，对于 OIer 来说更是只需了解，可按如下方式对函数的参数和返回值设置类型标注：
 
+```python
 def headline(
     text,           # type: str
     width = 80,       # type: int
@@ -715,7 +716,7 @@ def headline(
 
 print(headline("type comments work", width = 40))
 
-````
+```
 
 除了函数参数，变量也是可以类型标注的，你可以通过调用 `__annotations__` 来查看函数中所有的类型标注。变量类型标注赋予了 Python 静态语言的性质，即声明与赋值分离：
 


### PR DESCRIPTION
- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

把“类型标注”中的代码块按格式补充完整。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->
