### PR TITLE
fix(string/kmp.md)：修正Python代码中find_occurences这个的函数的一个错误，cur = s + '#' + t应该修改为cur = t + '#' + s

### DIFF
--- a/docs/string/kmp.md
+++ b/docs/string/kmp.md
@@ -256,7 +256,7 @@ $$
     
         ```python
         def find_occurences(s, t):
-            cur = s + '#' + t
+            cur = t + '#' + s
             sz1, sz2 = len(s), len(t)
             ret = []
             lps = prefix_function(cur)


### PR DESCRIPTION
`find_occurences`这个Python的函数代码存在一个错误`cur = s + '#' + t`应该修改为`cur = t + '#' + s`。

``` python
def find_occurences(s, t):
    cur = t + '#' + s
    sz1, sz2 = len(s), len(t)
    ret = []
    lps = prefix_function(cur)
    for i in range(sz2 + 1, sz1 + sz2 + 1):
        if lps[i] == sz2:
            ret.append(i - 2 * sz2)
    return ret
```