### PR TITLE
fix: math copy

### DIFF
--- a/docs/_static/css/extra.css
+++ b/docs/_static/css/extra.css
@@ -80,3 +80,8 @@ blockquote.page-copyright i.md-icon {
   background-color: var(--md-accent-fg-color);
   color: var(--md-code-bg-color);
 }
+
+mjx-container > img {
+  width: 0;
+  height: 0;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -557,7 +557,7 @@ extra_javascript:
   - 'assets/vendor/mathjax/es5/tex-mml-chtml.js?math-csr'
 
 extra_css:
-  - '_static/css/extra.css?v=13'
+  - '_static/css/extra.css?v=14'
 
 # Extensions
 markdown_extensions:

--- a/scripts/post-build/math/task-handler.ts
+++ b/scripts/post-build/math/task-handler.ts
@@ -84,7 +84,11 @@ export class MathRenderer {
 
   render(math: string, isDisplay: boolean) {
     const element = this.document.convert(math, { display: isDisplay }) as LiteElement;
-    this.adaptor.setAttribute(element, "title", math);
+    // @ts-expect-error the .create() method is wrongly set to protected
+    const emptyImg = this.adaptor.create("img");
+    this.adaptor.setAttribute(emptyImg, "src", "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7");
+    this.adaptor.setAttribute(emptyImg, "title", math);
+    this.adaptor.append(element, emptyImg);
     return this.adaptor.outerHTML(element);
   }
 }


### PR DESCRIPTION
使用一个零宽度的 `<img title="xxxxx">` 标签来实现公式的复制