### PR TITLE
fix(test.{yml,py}): 仅测试被修改的 C++ 文件

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,17 +14,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Get changed code files
+        id: changed-files
+        uses: tj-actions/changed-files@v35.4.1
+        with:
+          files: |
+            docs/**/*.cpp
       - uses: actions/setup-python@v4
+        if: steps.changed-files.outputs.any_changed == 'true'
         with:
           python-version: '3.10'
           cache: pipenv
       - name: Install Python dependencies
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python3
           pipenv install
       - name: Install C++
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: sudo apt-get install -y g++
       - name: Make the File list
-        run: find . -name *.cpp > res.txt
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: echo "${{ steps.changed-files.outputs.all_changed_files }}" > res.txt
       - name: Check the Code
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: pipenv run python scripts/test.py

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -9,11 +9,8 @@ def generate_annotations_and_exit(file, message):
     sys.exit(1)
 
 
-filename = "res.txt"
-with open(filename) as file_object:
-    lines = file_object.readlines()
-for line in lines:
-    name = line[:-5]
+def test(cppname):
+    name = cppname[:cppname.rfind('.')]
     num = name.rfind('/')
     content = name[:num]
     filename = name[num:]
@@ -29,7 +26,7 @@ for line in lines:
     # 判断测试是否要执行
     if os.path.exists(skiptest):
         print(cpp + ' test skipped')
-        continue
+        return
 
     cmd = 'g++ -std=c++17 '+cpp+' -o '+name
     # 判断CE
@@ -55,3 +52,10 @@ for line in lines:
     else:
         print(cpp + ' Wrong Answer')
         generate_annotations_and_exit(cpp, 'Wrong Answer')
+
+filename = "res.txt"
+with open(filename) as file_object:
+    lines = file_object.readlines()
+for line in lines:
+    for filename in line.split(' '):
+        test(filename)


### PR DESCRIPTION
- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

----

> 对测试 C++ 文件能否正常运行的工作流进行优化。

## 对比优化前后

- 优化前：所有 PR 的所有文件都需要检查
- 优化后：
  - 修改了 C++ 文件的 PR：**只测试修改的文件**
  - 未修改 C++ 文件的 PR：**跳过测试步骤**（_能正常通过检查_）

## 测试效果

如图，无论是否改动 C++ 文件，都能正常进行检查，解决了以前提出的问题（不执行检查导致无法合并）。

<details>
  <summary>【图】Green Run</summary>
  <img src="https://user-images.githubusercontent.com/83524927/212657513-d1911265-3ac3-4906-85d6-01ee0212e62f.jpg" alt="Green Run">
<p>All pages and graphics on this web site are the property of W3School.</p>
</details>

测试 PR 列表：
- yusancky#11 
- yusancky#17 
- yusancky#18 