### PR TITLE
fix(docs/math/simplex.md): 修改代码死循环

### DIFF
--- a/docs/math/simplex.md
+++ b/docs/math/simplex.md
@@ -318,7 +318,7 @@ bool Pivot(pair<size_t, size_t> &p) {  // 返回0表示所有的非轴元素都�
   double bmin = INT_MAX;
   for (size_t i = 1; i < bn; i++) {
     double tmp = B[i] / Matrix[i][y];
-    if (Matrix[i][y] != 0 && bmin > tmp) {
+    if (Matrix[i][y] != 0 && bmin > tmp && tmp > 0) {
       bmin = tmp;
       x = i;
     }


### PR DESCRIPTION
没有考虑到不对变量做出限制的情况，例如，输入

```
7 4
3 1 2 0 0 0 0
1 1 3 1 0 0 30
2 2 5 0 1 0 24
4 1 2 0 0 1 36
```

就会死循环，具体可以参见 国家集训队2016论文集《浅谈线性规划与对偶问题》P38

![](https://fastly.jsdelivr.net/gh/GaisaiYuno/imghost/202301262205179.png)

- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->
