### PR TITLE
fix(ds/code/persistent-seg/persistent-seg_1.cpp): 修正了原来因为没有正确按秩合并而导致复杂度错误的代码

### DIFF
--- a/docs/ds/code/persistent-seg/persistent-seg_1.cpp
+++ b/docs/ds/code/persistent-seg/persistent-seg_1.cpp
@@ -1,126 +1,129 @@
-#include<bits/stdc++.h>
+#include <bits/stdc++.h>
 using namespace std;
 
 struct SegmentTree {
-    int lc, rc, val, rnk;
+  int lc, rc, val, rnk;
 };
 
 const int MAXN = 100000 + 5;
 const int MAXM = 200000 + 5;
 
-SegmentTree t[MAXN * 2 + MAXM * 40]; //每次操作1会修改两次，一次修改父节点，一次修改父节点的秩
+SegmentTree
+    t[MAXN * 2 +
+      MAXM * 40];  //每次操作1会修改两次，一次修改父节点，一次修改父节点的秩
 int rt[MAXM];
 int n, m, tot;
 
 int build(int l, int r) {
-    int p = ++tot;
-    if(l == r) {
-        t[p].val = l;
-        t[p].rnk = 1;
-        return p;
-    }
-    int mid = (l + r) / 2;
-    t[p].lc = build(l, mid);
-    t[p].rc = build(mid + 1, r);
+  int p = ++tot;
+  if (l == r) {
+    t[p].val = l;
+    t[p].rnk = 1;
     return p;
+  }
+  int mid = (l + r) / 2;
+  t[p].lc = build(l, mid);
+  t[p].rc = build(mid + 1, r);
+  return p;
 }
 
-int getRnk(int p, int l, int r, int pos) { //查询秩
-    if(l == r) {
-        return t[p].rnk;
-    }
-    int mid = (l + r) / 2;
-    if(pos <= mid) {
-        return getRnk(t[p].lc, l, mid, pos);
-    } else {
-        return getRnk(t[p].rc, mid + 1, r, pos);
-    }
+int getRnk(int p, int l, int r, int pos) {  //查询秩
+  if (l == r) {
+    return t[p].rnk;
+  }
+  int mid = (l + r) / 2;
+  if (pos <= mid) {
+    return getRnk(t[p].lc, l, mid, pos);
+  } else {
+    return getRnk(t[p].rc, mid + 1, r, pos);
+  }
 }
 
-int modifyRnk(int now, int l, int r, int pos, int val) { //修改秩（高度）
-    int p = ++tot;
-    t[p] = t[now];
-    if(l == r) {
-        t[p].rnk = max(t[p].rnk, val);
-        return p;
-    }
-    int mid = (l + r) / 2;
-    if(pos <= mid) {
-        t[p].lc = modifyRnk(t[now].lc, l, mid, pos, val);
-    } else {
-        t[p].rc = modifyRnk(t[now].rc, mid + 1, r, pos, val);
-    }
+int modifyRnk(int now, int l, int r, int pos, int val) {  //修改秩（高度）
+  int p = ++tot;
+  t[p] = t[now];
+  if (l == r) {
+    t[p].rnk = max(t[p].rnk, val);
     return p;
+  }
+  int mid = (l + r) / 2;
+  if (pos <= mid) {
+    t[p].lc = modifyRnk(t[now].lc, l, mid, pos, val);
+  } else {
+    t[p].rc = modifyRnk(t[now].rc, mid + 1, r, pos, val);
+  }
+  return p;
 }
 
-int query(int p, int l, int r, int pos) { //查询父节点（序列中的值）
-    if(l == r) {
-        return t[p].val;
-    }
-    int mid = (l + r) / 2;
-    if(pos <= mid) {
-        return query(t[p].lc, l, mid, pos);
-    } else {
-        return query(t[p].rc, mid + 1, r, pos);
-    }
+int query(int p, int l, int r, int pos) {  //查询父节点（序列中的值）
+  if (l == r) {
+    return t[p].val;
+  }
+  int mid = (l + r) / 2;
+  if (pos <= mid) {
+    return query(t[p].lc, l, mid, pos);
+  } else {
+    return query(t[p].rc, mid + 1, r, pos);
+  }
 }
 
-int findRoot(int p, int pos) { //查询根节点
-    int f = query(p, 1, n, pos);
-    if(pos == f) {
-        return pos;
-    }
-    return findRoot(p, f);
+int findRoot(int p, int pos) {  //查询根节点
+  int f = query(p, 1, n, pos);
+  if (pos == f) {
+    return pos;
+  }
+  return findRoot(p, f);
 }
 
-int modify(int now, int l, int r, int pos, int fa) { //修改父节点（合并）
-    int p = ++tot;
-    t[p] = t[now];
-    if(l == r) {
-        t[p].val = fa;
-        return p;
-    }
-    int mid = (l + r) / 2;
-    if(pos <= mid) {
-        t[p].lc = modify(t[now].lc, l, mid, pos, fa);
-    } else {
-        t[p].rc = modify(t[now].rc, mid + 1, r, pos, fa);
-    }
+int modify(int now, int l, int r, int pos, int fa) {  //修改父节点（合并）
+  int p = ++tot;
+  t[p] = t[now];
+  if (l == r) {
+    t[p].val = fa;
     return p;
+  }
+  int mid = (l + r) / 2;
+  if (pos <= mid) {
+    t[p].lc = modify(t[now].lc, l, mid, pos, fa);
+  } else {
+    t[p].rc = modify(t[now].rc, mid + 1, r, pos, fa);
+  }
+  return p;
 }
 
 int main() {
-    scanf("%d%d", &n, &m);
-    rt[0] = build(1, n);
-    for(int i = 1; i <= m; i++) {
-        int op, a, b;
+  scanf("%d%d", &n, &m);
+  rt[0] = build(1, n);
+  for (int i = 1; i <= m; i++) {
+    int op, a, b;
 
-        scanf("%d", &op);
-        if(op == 1) {
-            scanf("%d%d", &a, &b);
-            int fa = findRoot(rt[i - 1], a), fb = findRoot(rt[i - 1], b);
-            if(fa != fb) {
-                if(getRnk(rt[i - 1], 1, n, fa) > getRnk(rt[i - 1], 1, n, fb)) { //按秩合并
-                    swap(fa, fb);
-                }
-                int tmp = modify(rt[i - 1], 1, n, fa, fb);
-                rt[i] = modifyRnk(tmp, 1, n, fb, getRnk(rt[i - 1], 1, n, fa) + 1);
-            } else {
-                rt[i] = rt[i - 1];
-            }
-        } else if(op == 2) {
-            scanf("%d", &a);
-            rt[i] = rt[a];
-        } else {
-            scanf("%d%d", &a, &b);
-            rt[i] = rt[i - 1];
-            if(findRoot(rt[i], a) == findRoot(rt[i], b)) {
-                printf("1\n");
-            } else {
-                printf("0\n");
-            }
+    scanf("%d", &op);
+    if (op == 1) {
+      scanf("%d%d", &a, &b);
+      int fa = findRoot(rt[i - 1], a), fb = findRoot(rt[i - 1], b);
+      if (fa != fb) {
+        if (getRnk(rt[i - 1], 1, n, fa) >
+            getRnk(rt[i - 1], 1, n, fb)) {  //按秩合并
+          swap(fa, fb);
         }
+        int tmp = modify(rt[i - 1], 1, n, fa, fb);
+        rt[i] = modifyRnk(tmp, 1, n, fb, getRnk(rt[i - 1], 1, n, fa) + 1);
+      } else {
+        rt[i] = rt[i - 1];
+      }
+    } else if (op == 2) {
+      scanf("%d", &a);
+      rt[i] = rt[a];
+    } else {
+      scanf("%d%d", &a, &b);
+      rt[i] = rt[i - 1];
+      if (findRoot(rt[i], a) == findRoot(rt[i], b)) {
+        printf("1\n");
+      } else {
+        printf("0\n");
+      }
     }
+  }
 
-    return 0;
+  return 0;
 }

--- a/docs/ds/code/persistent-seg/persistent-seg_1.cpp
+++ b/docs/ds/code/persistent-seg/persistent-seg_1.cpp
@@ -1,83 +1,126 @@
-#include <algorithm>
-#include <cstdio>
-const int N = 1e5, M = 2e5;  // 数据范围
+#include<bits/stdc++.h>
+using namespace std;
 
-struct node {
-  int val, rank, lchild, rchild;
-} tree[4 * N + M * 19];  // 每次操作增加节点数最多为 log2(4 * N) = 19
+struct SegmentTree {
+    int lc, rc, val, rnk;
+};
 
-int init[N + 1], root[M + 1], tot;
+const int MAXN = 100000 + 5;
+const int MAXM = 200000 + 5;
 
-int build(int l, int r) {  // 建树
-  int now = ++tot;
-  if (l == r) {
-    tree[now].val = init[l];
-    tree[now].rank = 1;
-    return now;
-  }
-  int mid = l + r >> 1;
-  tree[now].lchild = build(l, mid);
-  tree[now].rchild = build(mid + 1, r);
-  return now;
+SegmentTree t[MAXN * 2 + MAXM * 40]; //每次操作1会修改两次，一次修改父节点，一次修改父节点的秩
+int rt[MAXM];
+int n, m, tot;
+
+int build(int l, int r) {
+    int p = ++tot;
+    if(l == r) {
+        t[p].val = l;
+        t[p].rnk = 1;
+        return p;
+    }
+    int mid = (l + r) / 2;
+    t[p].lc = build(l, mid);
+    t[p].rc = build(mid + 1, r);
+    return p;
 }
 
-int update(int x, int l, int r, int target,
-           int newroot) {  // 合并操作-更新父亲节点信息
-  int now = ++tot;
-  tree[now] = tree[x];
-  if (l == r) {
-    tree[now].val = newroot;
-    tree[newroot].rank = std::max(tree[newroot].rank, tree[now].rank + 1);
-    return now;
-  }
-  int mid = l + r >> 1;
-  if (target <= mid)
-    tree[now].lchild = update(tree[x].lchild, l, mid, target, newroot);
-  else
-    tree[now].rchild = update(tree[x].rchild, mid + 1, r, target, newroot);
-  return now;
+int getRnk(int p, int l, int r, int pos) { //查询秩
+    if(l == r) {
+        return t[p].rnk;
+    }
+    int mid = (l + r) / 2;
+    if(pos <= mid) {
+        return getRnk(t[p].lc, l, mid, pos);
+    } else {
+        return getRnk(t[p].rc, mid + 1, r, pos);
+    }
 }
 
-int query(int x, int l, int r, int target) {  // 查询父亲节点
-  if (l == r) return tree[x].val;
-  int mid = l + r >> 1;
-  if (target <= mid)
-    return query(tree[x].lchild, l, mid, target);
-  else
-    return query(tree[x].rchild, mid + 1, r, target);
+int modifyRnk(int now, int l, int r, int pos, int val) { //修改秩（高度）
+    int p = ++tot;
+    t[p] = t[now];
+    if(l == r) {
+        t[p].rnk = max(t[p].rnk, val);
+        return p;
+    }
+    int mid = (l + r) / 2;
+    if(pos <= mid) {
+        t[p].lc = modifyRnk(t[now].lc, l, mid, pos, val);
+    } else {
+        t[p].rc = modifyRnk(t[now].rc, mid + 1, r, pos, val);
+    }
+    return p;
 }
 
-int getroot(int x, int l, int r, int target) {  // 查询根节点
-  int ans = query(x, l, r, target);
-  if (ans == target)
-    return ans;
-  else
-    return getroot(x, l, r, ans);
+int query(int p, int l, int r, int pos) { //查询父节点（序列中的值）
+    if(l == r) {
+        return t[p].val;
+    }
+    int mid = (l + r) / 2;
+    if(pos <= mid) {
+        return query(t[p].lc, l, mid, pos);
+    } else {
+        return query(t[p].rc, mid + 1, r, pos);
+    }
+}
+
+int findRoot(int p, int pos) { //查询根节点
+    int f = query(p, 1, n, pos);
+    if(pos == f) {
+        return pos;
+    }
+    return findRoot(p, f);
+}
+
+int modify(int now, int l, int r, int pos, int fa) { //修改父节点（合并）
+    int p = ++tot;
+    t[p] = t[now];
+    if(l == r) {
+        t[p].val = fa;
+        return p;
+    }
+    int mid = (l + r) / 2;
+    if(pos <= mid) {
+        t[p].lc = modify(t[now].lc, l, mid, pos, fa);
+    } else {
+        t[p].rc = modify(t[now].rc, mid + 1, r, pos, fa);
+    }
+    return p;
 }
 
 int main() {
-  int n, m;
-  scanf("%d%d", &n, &m);
-  for (int i = 1; i <= n; i++) init[i] = i;
-  root[0] = build(1, n);
-  int op, a, b, k;
-  for (int i = 1; i <= m; i++) {
-    scanf("%d", &op);
-    if (op == 1) {
-      scanf("%d%d", &a, &b);
-      int root_a = getroot(root[i - 1], 1, n, a);
-      int root_b = getroot(root[i - 1], 1, n, b);
-      if (tree[root_a].rank < tree[root_b].rank)  // 按秩合并
-        root[i] = update(root[i - 1], 1, n, root_a, root_b);
-      else
-        root[i] = update(root[i - 1], 1, n, root_b, root_a);
-    } else if (op == 2) {
-      scanf("%d", &k);
-      root[i] = root[k];
-    } else {
-      scanf("%d%d", &a, &b);
-      root[i] = root[i - 1];
-      printf("%d\n", getroot(root[i], 1, n, a) == getroot(root[i], 1, n, b));
+    scanf("%d%d", &n, &m);
+    rt[0] = build(1, n);
+    for(int i = 1; i <= m; i++) {
+        int op, a, b;
+
+        scanf("%d", &op);
+        if(op == 1) {
+            scanf("%d%d", &a, &b);
+            int fa = findRoot(rt[i - 1], a), fb = findRoot(rt[i - 1], b);
+            if(fa != fb) {
+                if(getRnk(rt[i - 1], 1, n, fa) > getRnk(rt[i - 1], 1, n, fb)) { //按秩合并
+                    swap(fa, fb);
+                }
+                int tmp = modify(rt[i - 1], 1, n, fa, fb);
+                rt[i] = modifyRnk(tmp, 1, n, fb, getRnk(rt[i - 1], 1, n, fa) + 1);
+            } else {
+                rt[i] = rt[i - 1];
+            }
+        } else if(op == 2) {
+            scanf("%d", &a);
+            rt[i] = rt[a];
+        } else {
+            scanf("%d%d", &a, &b);
+            rt[i] = rt[i - 1];
+            if(findRoot(rt[i], a) == findRoot(rt[i], b)) {
+                printf("1\n");
+            } else {
+                printf("0\n");
+            }
+        }
     }
-  }
+
+    return 0;
 }


### PR DESCRIPTION
修正了原来因为没有正确按秩合并而导致复杂度错误的代码。

原本的代码的 `tree` 数组储存的是线段树的节点，但在原本的代码的第 30 行和第 70 行等地方却误将其作为当前序列的内容使用。这一问题导致原本的代码提交到[洛谷上的对应模板题](https://www.luogu.com.cn/problem/P3402)后会出现 [TLE](https://www.luogu.com.cn/record/105014139)。之所以是 TLE，是因为没有正确按秩合并只影响复杂度，不影响逻辑上的正确性。同时因为原题数据强度不高，大部分测试点都能 AC。

新的代码修正了这一错误，并且在原题处提交时能够 [AC](https://www.luogu.com.cn/record/105078457)。

- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->
