### PR TITLE
fix(math/number-theory/primitive-root.md): 修改了关于原根符号不规范的问题

### DIFF
--- a/docs/math/number-theory/primitive-root.md
+++ b/docs/math/number-theory/primitive-root.md
@@ -181,9 +181,9 @@ $$
 
 ## 原根
 
-> **原根**：设 $m \in \mathbb{N}^{*}$，$a\in \mathbb{Z}$。若 $\gcd(a,m)=1$，且 $\delta_m(a)=\varphi(m)$，则称 $a$ 为模 $m$ 的原根。
+> **原根**：设 $m \in \mathbb{N}^{*}$，$g\in \mathbb{Z}$。若 $\gcd(g,m)=1$，且 $\delta_m(g)=\varphi(m)$，则称 $g$ 为模 $m$ 的原根。
 
-$g$ 满足 $\operatorname{ord}_n(g)=\left|Z_n^\times\right|=\varphi(n)$，对于质数 $p$，也就是说 $g^i \bmod p, 0 < i < p$ 结果互不相同。
+即 $g$ 满足 $\delta_m(g) = \left| Z_m^\times \right| = \varphi(m)$，当 $m$ 是质数时，我们有 $g^i \bmod m,\,0 \lt i \lt m$ 的结果互不相同。
 
 ???+ note "注"
     在抽象代数中，原根就是循环群的生成元。这个概念只在模 $m$ 缩剩余系关于乘法形成的群中有「原根」这个名字，在一般的循环群中都称作「生成元」。
@@ -192,27 +192,27 @@ $g$ 满足 $\operatorname{ord}_n(g)=\left|Z_n^\times\right|=\varphi(n)$，对于
 
 ### 原根判定定理
 
-> **原根判定定理**：设 $m \geqslant 3, \gcd(a,m)=1$，则 $a$ 是模 $m$ 的原根的充要条件是，对于 $\varphi(m)$ 的每个素因数 $p$，都有 $a^{\frac{\varphi(m)}{p}}\not\equiv 1\pmod m$。
+> **原根判定定理**：设 $m \geqslant 3, \gcd(g,m)=1$，则 $g$ 是模 $m$ 的原根的充要条件是，对于 $\varphi(m)$ 的每个素因数 $p$，都有 $g^{\frac{\varphi(m)}{p}}\not\equiv 1\pmod m$。
 
 **证明：** 必要性显然，下面用反证法证明充分性。
 
-当对于 $\varphi(m)$ 的每个素因数 $p$，都有 $a^{\frac{\varphi(m)}{p}}\not\equiv 1\pmod m$ 成立时，我们假设存在一个 $a$，其不是模 $m$ 的原根。
+当对于 $\varphi(m)$ 的每个素因数 $p$，都有 $g^{\frac{\varphi(m)}{p}}\not\equiv 1\pmod m$ 成立时，我们假设存在一个 $g$，其不是模 $m$ 的原根。
 
-因为 $a$ 不是 $m$ 的原根，则存在一个 $t<\varphi(m)$ 使得 $a^t\equiv 1\pmod{m}$。
+因为 $g$ 不是 $m$ 的原根，则存在一个 $t<\varphi(m)$ 使得 $g^t\equiv 1\pmod{m}$。
 
 由 [裴蜀定理](./bezouts.md) 得，一定存在一组 $k,x$ 满足 $kt=x\varphi(m)+\gcd(t,\varphi(m))$。
 
-又由 [欧拉定理](./fermat.md) 得 $a^{\varphi(m)}\equiv 1\pmod{m}$，故有：
+又由 [欧拉定理](./fermat.md) 得 $g^{\varphi(m)}\equiv 1\pmod{m}$，故有：
 
 $$
-1\equiv a^{kt}\equiv a^{x\varphi(m)+\gcd(t,\varphi(m))}\equiv a^{\gcd(t,\varphi(m))}\pmod{m}
+1\equiv g^{kt}\equiv g^{x\varphi(m)+\gcd(t,\varphi(m))}\equiv g^{\gcd(t,\varphi(m))}\pmod{m}
 $$
 
 由于 $\gcd(t, \varphi(m)) \mid \varphi(m)$ 且 $\gcd(t, \varphi(m))\leqslant t < \varphi(m)$。
 
 故存在 $\varphi(m)$ 的素因数 $p$ 使得 $\gcd(t, \varphi(m)) \mid \frac{\varphi(m)}{p}$。
 
-则 $a^{\frac{\varphi(m)}{p}}\equiv a^{(t, \varphi(m))}\equiv 1\pmod{m}$，与条件矛盾。
+则 $g^{\frac{\varphi(m)}{p}}\equiv g^{(t, \varphi(m))}\equiv 1\pmod{m}$，与条件矛盾。
 
 故假设不成立，原命题成立。
 


### PR DESCRIPTION
fix #4860

- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->
