### PR TITLE
fix(dp/basic.md): 修正最长不下降子序列中算法描述错误

### DIFF
--- a/docs/dp/basic.md
+++ b/docs/dp/basic.md
@@ -1,4 +1,4 @@
-author: Ir1d, CBW2007, ChungZH, xhn16729, Xeonacid, tptpp, hsfzLZH1, ouuan, Marcythm, HeRaNO, greyqz, Chrogeek, partychicken, zhb2000, xyf007, Persdre
+author: Ir1d, CBW2007, ChungZH, xhn16729, Xeonacid, tptpp, hsfzLZH1, ouuan, Marcythm, HeRaNO, greyqz, Chrogeek, partychicken, zhb2000, xyf007, Persdre, XiaoSuan250
 
 本页面主要介绍了动态规划的基本思想，以及动态规划中状态及状态转移方程的设计思路，帮助各位初学者对动态规划有一个初步的了解。
 
@@ -172,7 +172,7 @@ int dp() {
 考虑进来一个元素 $a_i$：
 
 1.  元素大于等于 $d_{len}$，直接将该元素插入到 $d$ 序列的末尾。
-2.  元素小于 $d_{len}$，找到 **第一个** 大于它的元素，插入进去，丢弃在它之后的全部元素。
+2.  元素小于 $d_{len}$，找到 **第一个** 大于它的元素，用 $a_i$ 替换它。
 
 参考代码如下：
 


### PR DESCRIPTION
原本对最长不下降子序列中算法二中
元素小于 $d_len$ 这种情况的描述是这样的：
> 找到 第一个 大于它的元素，插入进去，丢弃在它之后的全部元素。

而原文链接中的描述是：
> 准确的说，并不是接在谁后面。而是替换掉谁。

这时候，我们需要保留后面的元素，因为可能会在后面被使用到。
而且范例代码中也是在替换元素而不是丢弃之后的元素。

- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->
