### PR TITLE
fix(prime.md): 更正了 Miller-Rabin 算法 python 代码实现中的错误

### DIFF
--- a/docs/math/number-theory/prime.md
+++ b/docs/math/number-theory/prime.md
@@ -201,10 +201,11 @@
             if v == 1:
                 continue
             s = 0
-            for s in range(t):
+            while s < t:
                 if v == n - 1:
                     break
                 v = v * v % n
+                s = s + 1
             # 如果找到了非平凡平方根，则会由于无法提前 break; 而运行到 s == t
             # 如果 Fermat 素性测试无法通过，则一直运行到 s == t 前 v 都不会等于 -1
             if s == t:


### PR DESCRIPTION
这里的 `for s in range(t)` 估计是直接从 C++ `for(s = 0; s < t; ++s)` 改过来的，有严重的问题。python 中 `s` 在任何情况下都不可能增大到 `t` ，使得紧随其后的 `if s == t` 判断形同虚设。

- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。
