### PR TITLE
fix(sa.md): 删除 SA 示例中的冗余代码

### DIFF
--- a/docs/string/sa.md
+++ b/docs/string/sa.md
@@ -262,7 +262,6 @@ for (i = 1; i <= n; ++i) {
         for (p = 0, i = 1; i <= n; ++i)
           rk[sa[i]] = cmp(sa[i], sa[i - 1], w) ? p : ++p;
         if (p == n) {
-          for (int i = 1; i <= n; ++i) sa[rk[i]] = i;
           break;
         }
       }


### PR DESCRIPTION
"若排名都不相同可直接生成后缀数组"：示例代码中 p == n 时再次把 sa 重新按照 rk 生成了一遍，给人一种“后缀数组还没有搞完” 的错觉，实际上这句话冗余了，删去不影响结果，测试结果：https://loj.ac/s/1802384

- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->
