### PR TITLE
fix(intro/format.md): adjust example for multi-letter variable

### DIFF
--- a/docs/intro/format.md
+++ b/docs/intro/format.md
@@ -346,7 +346,7 @@ LaTeX 作为公式排版的首选，我们应当正确地使用它。因此对�
 | `$f[i][j][k]$`               | $f[i][j][k]$      | `$f_{i,j,k}$, $f(i,j,k)$`                | $f_{i,j,k}$，$f(i,j,k)$              |
 | `$R,N^*$`（集合）                | $R,N^*$           | `$\mathbf{R}$, $\mathbf{N}^*$`           | $\mathbf{R}$，$\mathbf{N}^*$         |
 | `$\emptyset$`                | $\emptyset$       | `$\varnothing$`                          | $\varnothing$                       |
-| `$size$`                | $size$       | `$\textit{size}$`                   | $\textit{size}$                |
+| `$size$`                     | $size$            | `$\textit{size}$`                        | $\textit{size}$                     |
 
 #### 对数学公式的附加格式要求
 

--- a/docs/intro/format.md
+++ b/docs/intro/format.md
@@ -346,7 +346,7 @@ LaTeX 作为公式排版的首选，我们应当正确地使用它。因此对�
 | `$f[i][j][k]$`               | $f[i][j][k]$      | `$f_{i,j,k}$, $f(i,j,k)$`                | $f_{i,j,k}$，$f(i,j,k)$              |
 | `$R,N^*$`（集合）                | $R,N^*$           | `$\mathbf{R}$, $\mathbf{N}^*$`           | $\mathbf{R}$，$\mathbf{N}^*$         |
 | `$\emptyset$`                | $\emptyset$       | `$\varnothing$`                          | $\varnothing$                       |
-| `$different$`                | $different$       | `$\textit{different}$`                   | $\textit{different}$                |
+| `$size$`                | $size$       | `$\textit{size}$`                   | $\textit{size}$                |
 
 #### 对数学公式的附加格式要求
 


### PR DESCRIPTION
`different` is too difficult to be recognized as a multi-letter variable, making this example hard to understand. This commit replace it with `size`, which is easier to be recognized as multi-letter variable.

- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->
