### PR TITLE
fix(string/suffix-bst): fix remove() for sgt

### DIFF
--- a/docs/string/code/suffix-bst/suffix-bst_2.cpp
+++ b/docs/string/code/suffix-bst/suffix-bst_2.cpp
@@ -95,21 +95,16 @@ void remove(int& rt, int p, double lv, double rv) {
   if (rt == p) {
     if (!L[rt] || !R[rt]) {
       rt = (L[rt] | R[rt]);
+      rebuild(rt, lv, rv);
     } else {
       // 找到rt的前驱来替换rt
-      int nrt = L[rt], fa = rt;
+      int nrt = L[rt];
       while (R[nrt]) {
-        fa = nrt;
-        sz[fa]--;
         nrt = R[nrt];
       }
-      if (fa == rt) {
-        R[nrt] = R[rt];
-      } else {
-        L[nrt] = L[rt];
-        R[nrt] = R[rt];
-        R[fa] = 0;
-      }
+      remove(L[rt], nrt, lv, tag[rt]);
+      L[nrt] = L[rt];
+      R[nrt] = R[rt];
       rt = nrt;
       tag[rt] = (lv + rv) / 2;
     }


### PR DESCRIPTION
- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 若本 Pull Request 能够完全解决某个 Issue，请将该 Pull Request 与对应的 Issue 链接起来，具体做法请参见 <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->
主要修正了sgt的remove()函数，修改点有两处：
1. 在有孩子是空的情况下，使用孩子替代自己后进行rebuild。
  这是因为此时孩子内的tag都不合法了，所以使用rebuild重新给它们的tag赋值。
  这时直接进行rebuild是常数代价的，因为有一个孩子为空，这个子树的大小（包括被remove的节点） $n$ 有上限：
  $$\alpha n \geq n - 1 \implies n \leq 1/(1-\alpha).$$
2. 在两个孩子均非空的情况下，使用一般二叉平衡树的删除方法，用左子树的最大值代替它，然后将它删除。

closes #4979 
closes #4985 