### PR TITLE
feat: add target="_blank" to external links via html-postprocess

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
           ./scripts/pre-build/pre-build.sh
           pipenv run mkdocs build -v
       - name: Post-process HTML
-        run: yarn ts-node-esm scripts/post-build/html-postprocess.ts commits-info math
+        run: yarn ts-node-esm scripts/post-build/html-postprocess.ts commits-info math external-links
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_OPTIONS: --max_old_space_size=3072

--- a/scripts/netlify/build.sh
+++ b/scripts/netlify/build.sh
@@ -17,4 +17,4 @@ pipenv run mkdocs build -v
 
 # Post-build scripts
 export NODE_OPTIONS="--max_old_space_size=3072"
-yarn ts-node-esm scripts/post-build/html-postprocess.ts commits-info math
+yarn ts-node-esm scripts/post-build/html-postprocess.ts commits-info math external-links

--- a/scripts/post-build/external-links/task-handler.ts
+++ b/scripts/post-build/external-links/task-handler.ts
@@ -1,0 +1,18 @@
+import { HTMLElement } from "node-html-parser";
+
+import { TaskHandler } from "../html-postprocess.js";
+
+const ROOT_URL = new URL("https://oi-wiki.org/");
+
+export const taskHandler = new (class implements TaskHandler<void> {
+  async process(document: HTMLElement) {
+    document.getElementsByTagName("a").forEach(element => {
+      const href = element.getAttribute("href");
+      if (new URL(href, ROOT_URL).origin !== ROOT_URL.origin) {
+        if ((element.getAttribute("target") || "").trim() === "") {
+          element.setAttribute("target", "_blank");
+        }
+      }
+    });
+  }
+})();

--- a/scripts/post-build/html-postprocess.ts
+++ b/scripts/post-build/html-postprocess.ts
@@ -7,7 +7,7 @@ import { parse, HTMLElement } from "node-html-parser";
 import klaw from "klaw";
 import chalk from "chalk";
 
-const TASKS = ["commits-info", "math"];
+const TASKS = ["commits-info", "math", "external-links"];
 const SITE_DIR = "site";
 
 const siteDir = path.resolve(SITE_DIR);


### PR DESCRIPTION
For external links (absolute link to domains rather than "oi-wiki.org") without a `target` attribute, set their `target` to `"_blank"`.