### PR TITLE
fix(shortest-path.md): SPFA python implementation

### DIFF
--- a/docs/graph/shortest-path.md
+++ b/docs/graph/shortest-path.md
@@ -277,7 +277,7 @@ SPFA 也可以用于判断 $s$ 点是否能抵达一个负环，只需记录最�
     === "Python"
     
         ```python
-        from collections import Deque
+        from collections import deque
         class Edge:
             def __init__(self, v = 0, w = 0):
                 self.v = v
@@ -286,7 +286,7 @@ SPFA 也可以用于判断 $s$ 点是否能抵达一个负环，只需记录最�
         e = [[Edge() for i in range(maxn)] for j in range(maxn)]
         dis = [0x3f3f3f3f] * maxn; cnt = [0] * maxn; vis = [False] * maxn
     
-        q = Deque()
+        q = deque()
         def spfa(n, s):
             dis[s] = 0
             vis[s] = True

--- a/docs/graph/shortest-path.md
+++ b/docs/graph/shortest-path.md
@@ -277,23 +277,23 @@ SPFA 也可以用于判断 $s$ 点是否能抵达一个负环，只需记录最�
     === "Python"
     
         ```python
+        from collections import Deque
         class Edge:
             def __init__(self, v = 0, w = 0):
                 self.v = v
                 self.w = w
     
         e = [[Edge() for i in range(maxn)] for j in range(maxn)]
-        dis = [0x3f3f3f3f] * maxn; cnt = [0] * maxn; vis = [0] * maxn
+        dis = [0x3f3f3f3f] * maxn; cnt = [0] * maxn; vis = [False] * maxn
     
-        q = []
+        q = Deque()
         def spfa(n, s):
             dis[s] = 0
-            vis[s] = 1
+            vis[s] = True
             q.append(s)
-            while len(q) != 0:
-                u = q[0]
-                vis[u] = 0
-                q.pop()
+            while q:
+                u = q.popleft()
+                vis[u] = False
                 for ed in e[u]:
                     if dis[v] > dis[u] + w:
                         dis[v] = dis[u] + w
@@ -302,7 +302,7 @@ SPFA 也可以用于判断 $s$ 点是否能抵达一个负环，只需记录最�
                             return False
                         # 在不经过负环的情况下，最短路至多经过 n - 1 条边
                         # 因此如果经过了多于 n 条边，一定说明经过了负环
-                        if vis[v] == False:
+                        if not vis[v]:
                             q.append(v)
                             vis[v] = True
         ```


### PR DESCRIPTION
原代码中u取的是队首元素，但是pop删除的是队尾元素
因为Python的list中append和pop只能在队尾操作，所以一般使用标准库collections中deque类（原理为双向链表）来实现队列。

- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 若本 Pull Request 能够完全解决某个 Issue，请将该 Pull Request 与对应的 Issue 链接起来，具体做法请参见 <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->
