### PR TITLE
fix(ds/monotonous-queue) 给队列一个正确的初始化

### DIFF
--- a/docs/ds/code/monotonous-queue/monotonous-queue_1.cpp
+++ b/docs/ds/code/monotonous-queue/monotonous-queue_1.cpp
@@ -8,7 +8,7 @@ int q[maxn], a[maxn];
 int n, k;
 
 void getmin() {  // 得到这个队列里的最小值，直接找到最后的就行了
-  int head = 0, tail = 0;
+  int head = 0, tail = -1;
   for (int i = 1; i < k; i++) {
     while (head <= tail && a[q[tail]] >= a[i]) tail--;
     q[++tail] = i;
@@ -22,7 +22,7 @@ void getmin() {  // 得到这个队列里的最小值，直接找到最后的就
 }
 
 void getmax() {  // 和上面同理
-  int head = 0, tail = 0;
+  int head = 0, tail = -1;
   for (int i = 1; i < k; i++) {
     while (head <= tail && a[q[tail]] <= a[i]) tail--;
     q[++tail] = i;


### PR DESCRIPTION
#### 修改队列初始化时尾指针指向。


- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。


原代码尽管可以得到正确的结果，但是有点奇怪。

队列指针初始化是有点问题的，按照该代码逻辑，`tail`指向为队列最后一个元素，`head`指向队列第一个元素，在这样的设定下，`tail`指向`head-1`处才表示空队列，但原代码并没有这样初始化。

原代码没有出bug的原因在于，一个没有初始化的全局数组默认初始化为全`0`值，那么对于第一次调用`get_min()`来说，由于`a`和`q`都被初始化为全`0`，那么

1. 对于`a[1]`，其必定要和`a[0]`对比，但`a[0]`本身并无意义，这样的比较也没有意义。
2. 如果`a`数组在第一个k大小的窗口内没有`<= 0`的值，则在处理完第一个窗口的值时，`q[0]`仍旧为0。在通过`q[head]`得到第一个窗口的最小值前，由于`q[0] <= i - k`，从而使得`head++`跳过了这个错误值。而由于`q[0]`仍旧为0，所以对于下一次调用`get_max()`，则如同本次调用`get_min()`一样，面临与本次调用`get_min()`相同的情况。
3. 如果`a`数组在第一个k大小的窗口内存在`<= 0`的值，那么对于第一个`<=0`的值`a[i]`，会让`tail--`，从而使得`tail=-1`，相当于做了一个初始化，该队列后续行为恰好符合一个从0开始的队列的形式，从而并没有问题。但它修改了`q[0]`的值，使得其并不为0，但对应的`a[q[0]]`必定`<=`第一个k大小窗口内的最小值，那么在调用`get_max()`时，在第一个k大小窗口内必定存在`a[i] >= a[q[0]]`从而使得`tail--`，此时又做了一次初始化，从而使得该队列后续表现正常。

综上：该代码可以得到一个正确的结果，但运行起来的方式有点奇怪，希望可以做一些调整，对队列的首尾指针做一个恰当的初始化。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 若本 Pull Request 能够完全解决某个 Issue，请将该 Pull Request 与对应的 Issue 链接起来，具体做法请参见 <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->
