### PR TITLE
fix(graph/save): 修正图存储中直接存边的bug

### DIFF
--- a/docs/graph/save.md
+++ b/docs/graph/save.md
@@ -67,15 +67,15 @@ author: Ir1d, sshwy, Xeonacid, partychicken, Anguei, HeRaNO
                 self.u = u
                 self.v = v
         
-        n, m = map(lambda x:int(x), input().split())
+        n, m = map(int, input().split())
         
         e = [Edge() for _ in range(m)]; vis = [False] * n
         
-        for i in range(0, m):
-            e[i].u, e[i].v = map(lambda x:int(x), input().split())
+        for i in range(m):
+            e[i].u, e[i].v = map(int, input().split())
         
         def find_edge(u, v):
-            for i in range(1, m + 1):
+            for i in range(m):
                 if e[i].u == u and e[i].v == v:
                     return True
             return False
@@ -84,7 +84,7 @@ author: Ir1d, sshwy, Xeonacid, partychicken, Anguei, HeRaNO
             if vis[u]:
                 return
             vis[u] = True
-            for i in range(1, m + 1):
+            for i in range(m):
                 if e[i].u == u:
                     dfs(e[i].v)
         ```


### PR DESCRIPTION
- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

直接存边中，刚开始初始化时，保存边的数组是从`0`开始的，后面遍历时是从`1`开始的。修正了该部分的bug。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 若本 Pull Request 能够完全解决某个 Issue，请将该 Pull Request 与对应的 Issue 链接起来，具体做法请参见 <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->
