### PR TITLE
fix(mkdocs.yml): edit button missing

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -554,6 +554,7 @@ theme:
   icon:
     logo: 'material/school'
   features:
+    - content.action.edit
     - navigation.tabs
     - navigation.instant
   font:


### PR DESCRIPTION
`content.action.edit` became an optional feature in material-mkdocs 9.0