### PR TITLE
fix(binary.md): 三分法实现中c++代码有误

### DIFF
--- a/docs/basic/binary.md
+++ b/docs/basic/binary.md
@@ -232,7 +232,7 @@ $$
 
 ```cpp
 while (r - l > eps) {
-  mid = (lmid + rmid) / 2;
+  mid = (l + r) / 2;
   lmid = mid - eps;
   rmid = mid + eps;
   if (f(lmid) < f(rmid))

--- a/docs/basic/binary.md
+++ b/docs/basic/binary.md
@@ -218,7 +218,7 @@ $$
 2 & \textbf{Output. } \text{The maximum value of } f(x) \text{ and the value of } x \text{ at that time } \text{.} \\
 3 & \textbf{Method. } \\
 4 & \textbf{while } r - l > \varepsilon\\
-5 & \qquad mid\gets \frac{lmid+rmid}{2}\\
+5 & \qquad mid\gets \frac{l+r}{2}\\
 6 & \qquad lmid\gets mid - \varepsilon \\
 7 & \qquad rmid\gets mid + \varepsilon \\
 8 & \qquad \textbf{if } f(lmid) < f(rmid) \\


### PR DESCRIPTION
在while循环中，mid的赋值应该取决于上次循环已经进行修改了的l和r，而不是lmid和rmid(使用lmid和rmid会陷入死循环)

- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 若本 Pull Request 能够完全解决某个 Issue，请将该 Pull Request 与对应的 Issue 链接起来，具体做法请参见 <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->
