### PR TITLE
fix(graph/matrix-tree): 修正笔误

### DIFF
--- a/docs/graph/matrix-tree.md
+++ b/docs/graph/matrix-tree.md
@@ -132,7 +132,7 @@ $\omega(l_i,d_j)=a_{i,j}$，$\omega(d_i,r_j)=b_{i,j}$。
 
 将余子式 $M_{i,j}$ 中除了 $\boldsymbol r_k$ 之外的所有 $\boldsymbol r_i$ 都加到 $\boldsymbol r_k$ 上，得到 $A=[\boldsymbol r_1,\cdots,\boldsymbol r_{j-1},\boldsymbol r_{j+1},\cdots,\boldsymbol r_{k-1},-\boldsymbol r_j,\boldsymbol r_{k+1},\cdots,\boldsymbol r_n]$。
 
-将 $-\boldsymbol r_j$ 取反并通过交换两列移动到 $\boldsymbol r_{j+1}$ 左边，得到 $|A|=M_{i,k}=(-1)^{1+(k-1)-(r+1)+1}M_{i,j}$，所以 $C_{i,j}=C_{i,k}$。
+将 $-\boldsymbol r_j$ 取反并通过交换两列移动到 $\boldsymbol r_{j+1}$ 左边，得到 $|A|=M_{i,k}=(-1)^{1+(k-1)-(j+1)+1}M_{i,j}$，所以 $C_{i,j}=C_{i,k}$。
 
 同理，删去第 $i$ 列后行向量之和为 $\boldsymbol 0$，得到 $C_{j,i}=C_{k,i}$。
 


### PR DESCRIPTION
性质1（Laplace 矩阵所有代数余子式的值都相等）中证明中有一处笔误，交换两列移动第 k 到第 j 列，所以对符号的影响应该是 (-1)^{1+(k-1)-(**j**+1)+1} 而不是 (-1)^{1+(k-1)-(**r**+1)+1}。

- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 若本 Pull Request 能够完全解决某个 Issue，请将该 Pull Request 与对应的 Issue 链接起来，具体做法请参见 <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->
