### PR TITLE
fix(geometry/convex-hull.md): Andrew算法的python代码

### DIFF
--- a/docs/geometry/convex-hull.md
+++ b/docs/geometry/convex-hull.md
@@ -76,17 +76,17 @@
         p = [] # 存储向量或点
         tp = 0 # 初始化栈
         p.sort() # 对点进行排序
-        stk[tp] = 1
         tp = tp + 1
+        stk[tp] = 1
         # 栈内添加第一个元素，且不更新 used，使得 1 在最后封闭凸包时也对单调栈更新
         for i in range(2, n + 1):
             while tp >= 2 and (p[stk[tp]] - p[stk[tp - 1]]) * (p[i] - p[stk[tp]]) <= 0:
                 # 下一行 * 操作符被重载为叉积
                 used[stk[tp]] = 0
                 tp = tp - 1
-                used[i] = 1 # used 表示在凸壳上
-                stk[tp] = i
-                tp = tp + 1
+            used[i] = 1 # used 表示在凸壳上
+            tp = tp + 1
+            stk[tp] = i
         tmp = tp # tmp 表示下凸壳大小
         for i in range(n - 1, 0, -1):
             if used[i] == False:
@@ -94,9 +94,9 @@
                 while tp > tmp and (p[stk[tp]] - p[stk[tp - 1]]) * (p[i] - p[stk[tp]]) <= 0:
                     used[stk[tp]] = 0
                     tp = tp - 1
-                    used[i] = 1
-                    stk[tp] = i
-                    tp = tp + 1
+                used[i] = 1
+                tp = tp + 1
+                stk[tp] = i
         for i in range(1, tp + 1):
             h[i] = p[stk[i]]
         ans = tp - 1


### PR DESCRIPTION
fix #5424
栈顶指针tp递增位置应位于入栈(stk[tp] = i)之前；
标记当前元素i在凸壳上、将i入栈的这三行代码应位于while循环之外（缩进问题）

- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 若本 Pull Request 能够完全解决某个 Issue，请将该 Pull Request 与对应的 Issue 链接起来，具体做法请参见 <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->
