### PR TITLE
fix(max-flow.md): Fix typo in the HLPP sample code

### DIFF
--- a/docs/graph/flow/max-flow.md
+++ b/docs/graph/flow/max-flow.md
@@ -956,7 +956,7 @@ HLPP 推送的条件是 $h(u)=h(v)+1$，而如果在算法的某一时刻，存�
         const int &v = e[i].t;
         const long long &w = e[i].v;
         // 初始化时不考虑高度差为1
-        if (!w || (init == false && ht[u] != ht[v] + 1) || t[v] == INF) continue;
+        if (!w || (init == false && ht[u] != ht[v] + 1) || ht[v] == INF) continue;
         long long k = init ? w : min(w, ex[u]);
         // 取到剩余容量和超额流的最小值，初始化时可以使源的溢出量为负数。
         if (v != s && v != t && !ex[v]) B[ht[v]].push(v), level = max(level, ht[v]);


### PR DESCRIPTION
- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

Fixed one typo in the hlpp sample code, at L39, `t[v]` -> `ht[v]`.

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 若本 Pull Request 能够完全解决某个 Issue，请将该 Pull Request 与对应的 Issue 链接起来，具体做法请参见 <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->
