### PR TITLE
fix(math/poly/fft): 修改递归版 FFT 代码实现

### DIFF
--- a/docs/math/poly/fft.md
+++ b/docs/math/poly/fft.md
@@ -247,16 +247,13 @@ $$
       Comp *g = f, *h = f + n / 2;
       // 递归 DFT
       DFT(g, n / 2, rev), DFT(h, n / 2, rev);
-      // cur 是当前单位复根，对于 k = 0 而言，它对应的单位复根 omega^0_n = 1。
-      // step 是两个单位复根的差，即满足 omega^k_n = step*omega^{k-1}*n，
-      // 定义等价于 exp(I*(2*M_PI/n*rev))
-      Comp cur(1, 0), step(cos(2 * M_PI / n), sin(2 * M_PI * rev / n));
       for (int k = 0; k < n / 2;
            ++k) {  // F(omega^k_n) = G(omega^k*{n/2}) + omega^k*n\*H(omega^k*{n/2})
+        // cur 是当前单位复根，定义等价于 exp(I*(2*M_PI/n*rev))
+        Comp cur(cos(2 * k * M_PI / n), sin(2 * k * M_PI * rev / n));
         tmp[k] = g[k] + cur * h[k];
         // F(omega^{k+n/2}*n) = G(omega^k*{n/2}) - omega^k_n*H(omega^k\_{n/2})
         tmp[k + n / 2] = g[k] - cur * h[k];
-        cur *= step;
       }
       for (int i = 0; i < n; ++i) f[i] = tmp[i];
     }


### PR DESCRIPTION
原来的 FFT 中，定义了旋转角度 `step`，并通过 `cur *= step` 不断计算下一个单位根。这种做法会随着循环逐渐累积浮点数的精度误差，最终误差太大，在洛谷模板题 P3803 会 WA。因此修改为直接调用 sin，cos 计算每一次的单位根。

- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 若本 Pull Request 能够完全解决某个 Issue，请将该 Pull Request 与对应的 Issue 链接起来，具体做法请参见 <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->
