### PR TITLE
fix(docs/contest/common-mistakes.md): 删去一个错项

### DIFF
--- a/docs/contest/common-mistakes.md
+++ b/docs/contest/common-mistakes.md
@@ -158,7 +158,6 @@ author: H-J-Granger, orzAtalod, ksyx, Ir1d, Chrogeek, Enter-tainer, yiyangit, sh
         }
         ```
 
-    -   特别的，也不能在执行 `ios::sync_with_stdio(false);` 后使用 `freopen`。
 
 -   由于宏的展开，且未加括号导致的错误。
 

--- a/docs/contest/common-mistakes.md
+++ b/docs/contest/common-mistakes.md
@@ -158,7 +158,6 @@ author: H-J-Granger, orzAtalod, ksyx, Ir1d, Chrogeek, Enter-tainer, yiyangit, sh
         }
         ```
 
-
 -   由于宏的展开，且未加括号导致的错误。
 
     -   示例：该宏返回的值并非 $4^2 = 16$ 而是 $2+2\times 2+2 = 8$。


### PR DESCRIPTION
删去了“特别的，也不能在执行 ios::sync_with_stdio(false); 后使用 freopen。”。这并没有理论依据，且很可能是无中生有的说法。

- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 若本 Pull Request 能够完全解决某个 Issue，请将该 Pull Request 与对应的 Issue 链接起来，具体做法请参见 <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->
