### PR TITLE
feat: feedback-sys commit offsets patch

### DIFF
--- a/.github/workflows/update-feedback-sys-meta.yml
+++ b/.github/workflows/update-feedback-sys-meta.yml
@@ -1,3 +1,5 @@
+name: Update Feedback System Meta
+
 on:
   push:
     branches:

--- a/.github/workflows/update-feedback-sys-meta.yml
+++ b/.github/workflows/update-feedback-sys-meta.yml
@@ -1,0 +1,40 @@
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_feedback_sys_meta:
+    name: Update OI-Wiki Feedback System Meta From Diff
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout latest
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Get changed files
+        uses: tj-actions/changed-files@v44
+        with:
+          files: docs/**/*.md
+          base_sha: ${{ github.event.before }}
+          sha: ${{ github.event.after}}
+          include_all_old_new_renamed_files: true
+          write_output_files: true
+      - name: Checkout before
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.before }}
+          path: before
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+            python-version: '3.10'
+      - name: Install Python dependencies
+        run: |
+          curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python3
+          pipenv install
+      - name: Compare and apply diff
+        run: |
+          pipenv run python scripts/update-feedback-sys-meta.py --modified .github/outputs/modified_files.txt --renamed .github/outputs/all_old_new_renamed_files.txt --before_dir before
+        env:
+          ADMINISTRATOR_SECRET: ${{ secrets.FEEDBACK_SYS_ADMINISTRATOR_SECRET }}

--- a/scripts/update-feedback-sys-meta.py
+++ b/scripts/update-feedback-sys-meta.py
@@ -9,24 +9,6 @@ import urllib.parse
 
 API_ENDPOINT = "https://cloudflare-workers.hikarilan.workers.dev/"
 
-parser = argparse.ArgumentParser("update-feedback-sys-meta")
-parser.add_argument("--modified", type=FileType(encoding="utf-8"), required=True)
-parser.add_argument("--renamed", type=FileType(encoding="utf-8"), required=True)
-parser.add_argument("--before_dir", type=str, required=True)
-args = parser.parse_args()
-
-modified: list[str] = args.modified.read().split(" ")
-renamed: list[(str, str)] = [
-    tuple((files.split(",")[0], files.split(",")[1]))
-    for files in args.renamed.read().split(" ")
-]
-
-before_dir: str = args.before_dir
-
-print("Modified:", modified)
-print("Renamed:", renamed)
-print("Before dir:", before_dir)
-
 def remove_meta(doc: str) -> str:
     """
     See issue: https://github.com/squidfunk/mkdocs-material/issues/4179
@@ -79,22 +61,42 @@ def path_to_url(
 
     return str(path) + ("/" if path.name != "" else "")
 
-for path in modified:
-    requests.patch(
-        API_ENDPOINT
-        + "comment/{encoded_path}".format(
-            encoded_path=urllib.parse.quote(path_to_url(path))
-        ),
-        headers={"Authorization": "Bearer " + os.environ["ADMINISTRATOR_SECRET"]},
-        json={"type": "modified", "diff": dump_diff(path)},
-    )
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser("update-feedback-sys-meta")
+    parser.add_argument("--modified", type=FileType(encoding="utf-8"), required=True)
+    parser.add_argument("--renamed", type=FileType(encoding="utf-8"), required=True)
+    parser.add_argument("--before_dir", type=str, required=True)
 
-for path_from, path_to in renamed:
-    requests.patch(
-        API_ENDPOINT
-        + "comment/{encoded_path}".format(
-            encoded_path=urllib.parse.quote(path_to_url(path_from))
-        ),
-        headers={"Authorization": "Bearer " + os.environ["ADMINISTRATOR_SECRET"]},
-        json={"type": "renamed", "to": path_to_url(path_to)},
-    )
+    args = parser.parse_args()
+
+    modified: list[str] = args.modified.read().split(" ")
+    renamed: list[(str, str)] = [
+        tuple((files.split(",")[0], files.split(",")[1]))
+        for files in args.renamed.read().split(" ")
+    ]
+
+    before_dir: str = args.before_dir
+
+    print("Modified:", modified)
+    print("Renamed:", renamed)
+    print("Before dir:", before_dir)
+
+    for path in modified:
+        requests.patch(
+            API_ENDPOINT
+            + "comment/{encoded_path}".format(
+                encoded_path=urllib.parse.quote(path_to_url(path))
+            ),
+            headers={"Authorization": "Bearer " + os.environ["ADMINISTRATOR_SECRET"]},
+            json={"type": "modified", "diff": dump_diff(path)},
+        )
+
+    for path_from, path_to in renamed:
+        requests.patch(
+            API_ENDPOINT
+            + "comment/{encoded_path}".format(
+                encoded_path=urllib.parse.quote(path_to_url(path_from))
+            ),
+            headers={"Authorization": "Bearer " + os.environ["ADMINISTRATOR_SECRET"]},
+            json={"type": "renamed", "to": path_to_url(path_to)},
+        )

--- a/scripts/update-feedback-sys-meta.py
+++ b/scripts/update-feedback-sys-meta.py
@@ -14,7 +14,12 @@ parser.add_argument("--modified", type=FileType(encoding="utf-8"), required=True
 parser.add_argument("--renamed", type=FileType(encoding="utf-8"), required=True)
 parser.add_argument("--before_dir", type=str, required=True)
 args = parser.parse_args()
-modified: list[str] = args.modified.read().split(" ")
+
+modified_file = args.modified.read().split(" ")
+modified: list[str] = []
+for f in modified_file:
+    if(len(f) > 0):
+        modified.append(f)
 
 renamed_file = args.renamed.read()
 renamed: list[(str, str)] = []

--- a/scripts/update-feedback-sys-meta.py
+++ b/scripts/update-feedback-sys-meta.py
@@ -98,4 +98,3 @@ for path_from, path_to in renamed:
         headers={"Authorization": "Bearer " + os.environ["ADMINISTRATOR_SECRET"]},
         json={"type": "renamed", "to": path_to_url(path_to)},
     )
-    pass

--- a/scripts/update-feedback-sys-meta.py
+++ b/scripts/update-feedback-sys-meta.py
@@ -15,10 +15,14 @@ parser.add_argument("--renamed", type=FileType(encoding="utf-8"), required=True)
 parser.add_argument("--before_dir", type=str, required=True)
 args = parser.parse_args()
 modified: list[str] = args.modified.read().split(" ")
-renamed: list[(str, str)] = [
-    tuple((files.split(",")[0], files.split(",")[1]))
-    for files in args.renamed.read().split(" ")
-]
+
+renamed_file = args.renamed.read()
+renamed: list[(str, str)] = []
+for files in renamed_file.split(" "):
+    f = files.split(",")
+    if(len(f) == 2):
+        renamed.append((f[0], f[1]))
+
 before_dir: str = args.before_dir
 print("Modified:", modified)
 print("Renamed:", renamed)

--- a/scripts/update-feedback-sys-meta.py
+++ b/scripts/update-feedback-sys-meta.py
@@ -1,0 +1,101 @@
+import argparse
+from argparse import FileType
+from difflib import SequenceMatcher
+import os
+from pathlib import PurePosixPath, Path
+import re
+import requests
+import urllib.parse
+
+API_ENDPOINT = "https://cloudflare-workers.hikarilan.workers.dev/"
+
+parser = argparse.ArgumentParser("update-feedback-sys-meta")
+parser.add_argument("--modified", type=FileType(encoding="utf-8"), required=True)
+parser.add_argument("--renamed", type=FileType(encoding="utf-8"), required=True)
+parser.add_argument("--before_dir", type=str, required=True)
+args = parser.parse_args()
+
+modified: list[str] = args.modified.read().split(" ")
+renamed: list[(str, str)] = [
+    tuple((files.split(",")[0], files.split(",")[1]))
+    for files in args.renamed.read().split(" ")
+]
+
+before_dir: str = args.before_dir
+
+print("Modified:", modified)
+print("Renamed:", renamed)
+print("Before dir:", before_dir)
+
+def remove_meta(doc: str) -> str:
+    """
+    See issue: https://github.com/squidfunk/mkdocs-material/issues/4179
+    @Source: https://github.com/mkdocs/mkdocs/blob/master/mkdocs/utils/meta.py
+    """
+    META_RE = re.compile(r'^[ ]{0,3}(?P<key>[A-Za-z0-9_-]+):\s*(?P<value>.*)')
+    META_MORE_RE = re.compile(r'^([ ]{4}|\t)(\s*)(?P<value>.*)')
+    
+    lines = doc.replace('\r\n', '\n').replace('\r', '\n').split('\n')
+    
+    while lines:
+        line = lines.pop(0)
+
+        if line.strip() == '':
+            break  # blank line - done
+        
+        if not META_RE.match(line) and not META_MORE_RE.match(line):
+            lines.insert(0, line)
+            break  # no meta data - done
+        
+    return '\n'.join(lines).lstrip('\n')
+
+
+def dump_diff(path: str, before_dir: str = before_dir):
+    before = (Path(before_dir) / path).read_text(encoding="utf-8")
+    after = Path(path).read_text(encoding="utf-8")
+    
+    before = remove_meta(before)
+    after = remove_meta(after)
+
+    diff = SequenceMatcher(None, before, after)
+
+    return [
+        {"tag": tag, "i1": i1, "i2": i2, "j1": j1, "j2": j2}
+        for (tag, i1, i2, j1, j2) in diff.get_opcodes()
+        if tag != "equal"
+    ]
+    
+def path_to_url(
+    raw_path: str, base_dir: str = "docs", index_file: str = "index.md"
+) -> str:
+    path = PurePosixPath(raw_path).relative_to(base_dir)
+
+    if path.name == index_file:
+        path = path.parent
+    else:
+        path = path.with_suffix("")
+
+    path = "/" / path
+
+    return str(path) + ("/" if path.name != "" else "")
+
+for path in modified:
+    requests.patch(
+        API_ENDPOINT
+        + "comment/{encoded_path}".format(
+            encoded_path=urllib.parse.quote(path_to_url(path))
+        ),
+        headers={"Authorization": "Bearer " + os.environ["ADMINISTRATOR_SECRET"]},
+        json={"type": "modified", "diff": dump_diff(path)},
+    )
+
+for path_from, path_to in renamed:
+    requests.patch(
+        API_ENDPOINT
+        + "comment/{encoded_path}".format(
+            encoded_path=urllib.parse.quote(path_to_url(path_from))
+        ),
+        headers={"Authorization": "Bearer " + os.environ["ADMINISTRATOR_SECRET"]},
+        json={"type": "renamed", "to": path_to_url(path_to)},
+    )
+    pass

--- a/scripts/update-feedback-sys-meta.py
+++ b/scripts/update-feedback-sys-meta.py
@@ -100,7 +100,12 @@ if __name__ == '__main__':
             json={"type": "modified", "diff": dump_diff(path)},
         )
         
-    renamed_modified = [path_from, path_to for path_from, path_to in renamed if len(dump_diff(path_to, oldPath = path_from)) > 0]
+    renamed_modified = []
+    for path_from, path_to in renamed:
+        diff = dump_diff(path_to, oldPath = path_from)
+        if len(diff) > 0:
+            renamed_modified.append((path_from, path_to))
+            
     for path_from, path_to in renamed_modified:
         requests.patch(
             API_ENDPOINT

--- a/scripts/update-feedback-sys-meta.py
+++ b/scripts/update-feedback-sys-meta.py
@@ -100,7 +100,8 @@ if __name__ == '__main__':
             json={"type": "modified", "diff": dump_diff(path)},
         )
         
-    for path_from, path_to in [path_from, path_to for path_from, path_to in renamed if len(dump_diff(path_to, oldPath = path_from)) > 0]:
+    renamed_modified = [path_from, path_to for path_from, path_to in renamed if len(dump_diff(path_to, oldPath = path_from)) > 0]
+    for path_from, path_to in renamed_modified:
         requests.patch(
             API_ENDPOINT
             + "comment/{encoded_path}".format(


### PR DESCRIPTION
- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 若本 Pull Request 能够完全解决某个 Issue，请将该 Pull Request 与对应的 Issue 链接起来，具体做法请参见 <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->

此 pr 提供 feedback-sys 在源文档发生更改时对评论位置数据的动态修正能力。该 pr 增加的功能如下：

- 新增了一个 github workflow，旨在有新的主线 push 侦测 docs/ 目录下的文件更改，并收集这些信息
- 将上述数据传递给 `scripts/update-feedback-sys-meta.py`，该文件会计算更改，然后将计算结果传递给 workers 后端，由后端进行进一步分析并进行修改
- 对于文件重命名，也会遵循上述方案，来自动更改后端存储的相关数据

查看 https://github.com/OI-wiki/feedback-sys/pull/27 可以获得有关该功能的更多信息。