### PR TITLE
fix(math/number-theory/basic.md): 修改内容层级关系&修正莫比乌斯函数性质

### DIFF
--- a/docs/math/number-theory/basic.md
+++ b/docs/math/number-theory/basic.md
@@ -401,14 +401,14 @@ $$
 
 数论函数指定义域为正整数的函数。数论函数也可以视作一个数列。
 
-## 积性函数
+### 积性函数
 
 ???+ note "定义"
     若函数 $f(n)$ 满足 $f(1)=1$ 且 $\forall x,y\in\mathbf{N}^*,~(x,y)=1$ 都有 $f(xy)=f(x)f(y)$，则 $f(n)$ 为 **积性函数**。
     
     若函数 $f(n)$ 满足 $f(1)=1$ 且 $\forall x,y\in\mathbf{N}^*$ 都有 $f(xy)=f(x)f(y)$，则 $f(n)$ 为 **完全积性函数**。
 
-### 性质
+#### 性质
 
 若 $f(x)$ 和 $g(x)$ 均为积性函数，则以下函数也为积性函数：
 
@@ -427,20 +427,14 @@ $$
 
 若 $F(x)$ 为完全积性函数，则有 $F(x)=\prod F(p_i)^{k_i}$。
 
-### 例子
+#### 例子
 
 -   单位函数：$\varepsilon(n)=[n=1]$。（完全积性）
 -   恒等函数：$\operatorname{id}_k(n)=n^k$，$\operatorname{id}_{1}(n)$ 通常简记作 $\operatorname{id}(n)$。（完全积性）
 -   常数函数：$1(n)=1$。（完全积性）
 -   除数函数：$\sigma_{k}(n)=\sum_{d\mid n}d^{k}$。$\sigma_{0}(n)$ 通常简记作 $d(n)$ 或 $\tau(n)$，$\sigma_{1}(n)$ 通常简记作 $\sigma(n)$。
--   欧拉函数：$\varphi(n)=\sum_{i=1}^n[(i,n)=1]$
--   莫比乌斯函数：$\mu(n)=\begin{cases}1&n=1\\0&\exists d>1,d^{2}\mid n\\(-1)^{\omega(n)}&\text{otherwise}\end{cases}$，其中 $\omega(n)$ 表示 $n$ 的本质不同质因子个数，它是一个加性函数。
-
-???+ note "加性函数"
-    此处加性函数指数论上的加性函数 (Additive function)。对于加性函数 $f$，当整数 $a,b$ 互质时，均有 $f(ab)=f(a)+f(b)$。
-    应与代数中的加性函数 (Additive map) 区分。
-
-***
+-   欧拉函数：$\varphi(n)=\sum_{i=1}^n[(i,n)=1]$。
+-   莫比乌斯函数：$\mu(n)=\begin{cases}1&n=1\\0&\exists d>1,d^{2}\mid n\\(-1)^{\omega(n)}&\text{otherwise}\end{cases}$，其中 $\omega(n)$ 表示 $n$ 的本质不同质因子个数。
 
 ## 参考资料与注释
 


### PR DESCRIPTION
- 将积性函数移至数论函数之下
- 将莫比乌斯函数性质修正为积性函数及删去附带的加性函数表述

- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 若本 Pull Request 能够完全解决某个 Issue，请将该 Pull Request 与对应的 Issue 链接起来，具体做法请参见 <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->

### 内容修正

1. 莫比乌斯函数不是加性函数（Additive function），故删去相关句段。
2. 积性函数属于数论函数，故调整层级。

### 格式修正

1. 该列表本身为积性函数举例，故不再重复阐述其性质。
2. 标点符号补全。

### 详细说明

修正[该PR](https://github.com/OI-wiki/OI-wiki/pull/2839)的错误编辑。

数论中的加性函数：对于正整数n的一个算术函数f(n)，当中f(1)=1且当(a,b)=1，f(ab)=f(a)+f(b)，在数论上就称它为加性函数。

由加性函数性质之一f(1)=0易知莫比乌斯函数不是加性函数，简单举例亦可得知。