### PR TITLE
fix: en.cppreference to zh.cppreference

### DIFF
--- a/docs/ds/sparse-table.md
+++ b/docs/ds/sparse-table.md
@@ -68,7 +68,7 @@ ST 表基于 [倍增](../basic/binary-lifting.md) 思想，可以做到 $\Theta(
 
 1.  输入输出数据一般很多，建议开启输入输出优化。
 
-2.  每次用 [std::log](https://en.cppreference.com/w/cpp/numeric/math/log) 重新计算 log 函数值并不值得，建议进行如下的预处理：
+2.  每次用 [std::log](https://zh.cppreference.com/w/cpp/numeric/math/log) 重新计算 log 函数值并不值得，建议进行如下的预处理：
 
 $$
 \begin{cases}

--- a/docs/intro/format.md
+++ b/docs/intro/format.md
@@ -506,11 +506,11 @@ $$
 -   您的代码需要同时支持在 C++14、C++17、C++20 标准下编译和运行。
 -   不要使用 `<bits/stdc++.h>`、`<bits/extc++.h>` 等非标准头文件。
 -   标准答案文件不要有多余空格。
--   不要使用 [代用记号](https://en.cppreference.com/w/cpp/language/operator_alternative#Alternative_tokens)。
--   使用 [聚合初始化](https://en.cppreference.com/w/cpp/language/aggregate_initialization) 时，`object{args}` 不可写成 `(object){args}`。
--   使用 [运算符重载](https://en.cppreference.com/w/cpp/language/operators) 时注意格式，如重载比较运算符时，若使用成员函数写法，则不可省略 `const` 限定符。
+-   不要使用 [代用记号](https://zh.cppreference.com/w/cpp/language/operator_alternative#Alternative_tokens)。
+-   使用 [聚合初始化](https://zh.cppreference.com/w/cpp/language/aggregate_initialization) 时，`object{args}` 不可写成 `(object){args}`。
+-   使用 [运算符重载](https://zh.cppreference.com/w/cpp/language/operators) 时注意格式，如重载比较运算符时，若使用成员函数写法，则不可省略 `const` 限定符。
 -   不要使用类似 `#define int long long` 的宏定义。
--   若您需要使用 C 风格的 [有格式输入/输出](https://en.cppreference.com/w/cpp/io/c#Formatted_input.2Foutput)，请特别留意格式指示符的写法：如 `size_t` 对应 `%zu`，`ptrdiff_t` 对应 `%td`。例如输出某 STL 容器的大小时，代码应类似 `printf("%zu", container.size());`。
+-   若您需要使用 C 风格的 [有格式输入/输出](https://zh.cppreference.com/w/cpp/io/c#Formatted_input.2Foutput)，请特别留意格式指示符的写法：如 `size_t` 对应 `%zu`，`ptrdiff_t` 对应 `%td`。例如输出某 STL 容器的大小时，代码应类似 `printf("%zu", container.size());`。
 -   由于当前测试环境 libstdc++ 的 `<chrono>` 库有 [BUG](https://github.com/actions/runner-images/issues/8659)，所以请避免使用 `<chrono>` 库。
 -   由于 `long` 与 `unsigned long` 在某些测试环境下为 32 位，而在另一些测试环境下为 64 位，为确保各平台代码行为一致，故不推荐使用这两种类型。推荐使用 [定宽整数类型](../lang/var.md#定宽整数类型)。
 -   不建议使用 `__gcd`、`__int128`、`__builtin_` 系列函数等非标准内容。如果您需要使用，则需确保您的代码能通过全平台测试，如 [此代码](https://github.com/OI-wiki/OI-wiki/blob/4af83d6db6017f4c36db6d4a7583bbc3f6257484/docs/ds/code/tree-decompose/tree-decompose_1.cpp#L24-L47) 提供了 libstdc++ 中 [std::bitset](../lang/csl/bitset.md) 特有成员函数 `_Find_first()` 的全平台实现。
@@ -520,7 +520,7 @@ $$
 -   代码应尽可能简洁易懂，不要过度压行，不要引入过多无关代码（如未使用的宏定义等）。
 -   不推荐对函数使用 `inline` 关键字，详见 [编译优化](../lang/optimizations.md#inline---内联)。
 -   不要用 `0` 代替 `false`/`NULL`/`nullptr` 等，不要用 `1` 代替 `true` 等。
--   在声明 [类型别名](https://en.cppreference.com/w/cpp/language/type_alias) 时，不推荐使用 `typedef`，推荐使用 `using`。
+-   在声明 [类型别名](https://zh.cppreference.com/w/cpp/language/type_alias) 时，不推荐使用 `typedef`，推荐使用 `using`。
 -   不推荐用宏定义定义常量，推荐直接使用 `constexpr`/`const` 等关键字定义常量。
 
 ## 图解

--- a/docs/lang/cpp-other-langs.md
+++ b/docs/lang/cpp-other-langs.md
@@ -76,7 +76,7 @@ C99 后 C 语言支持 VLA（可变长数组），C++ 始终不支持。
 
 ### 结构体初始化
 
-C99 后 C 语言支持结构体的 [指派符初始化](https://en.cppreference.com/w/c/language/struct_initialization)（但是在 C11 中为可选特性），C++ 直到 C++20 才支持有顺序要求的指派符初始化，且 C 语言支持的乱序、嵌套、与普通初始化器混用、数组的指派符初始化特性 C++ 都不支持[^cpp-designated-init]。
+C99 后 C 语言支持结构体的 [指派符初始化](https://zh.cppreference.com/w/c/language/struct_initialization)（但是在 C11 中为可选特性），C++ 直到 C++20 才支持有顺序要求的指派符初始化，且 C 语言支持的乱序、嵌套、与普通初始化器混用、数组的指派符初始化特性 C++ 都不支持[^cpp-designated-init]。
 
 ### 注释语法
 

--- a/docs/lang/csl/bitset.md
+++ b/docs/lang/csl/bitset.md
@@ -30,7 +30,7 @@ author: i-Yirannn, Xeonacid, ouuan
 
 ## 使用
 
-参见 [std::bitset - cppreference.com](https://en.cppreference.com/w/cpp/utility/bitset)。
+参见 [std::bitset - cppreference.com](https://zh.cppreference.com/w/cpp/utility/bitset)。
 
 ### 头文件
 

--- a/docs/lang/csl/iterator.md
+++ b/docs/lang/csl/iterator.md
@@ -58,4 +58,4 @@ for (vector<int>::iterator iter = data.begin(); iter != data.end(); iter++)
 
 [STL 容器](./container.md) 一般支持从一端或两端开始的访问，以及对 [const 修饰符](../const.md) 的支持。例如容器的 `begin()` 函数可以获得指向容器第一个元素的迭代器，`rbegin()` 函数可以获得指向容器最后一个元素的反向迭代器，`cbegin()` 函数可以获得指向容器第一个元素的 const 迭代器，`end()` 函数可以获得指向容器尾端（「尾端」并不是最后一个元素，可以看作是最后一个元素的后继；「尾端」的前驱是容器里的最后一个元素，其本身不指向任何一个元素）的迭代器。
 
-可在 [Iterator library - cppreference.com](https://en.cppreference.com/w/cpp/iterator) 查看更多用法。
+可在 [Iterator library - cppreference.com](https://zh.cppreference.com/w/cpp/iterator) 查看更多用法。

--- a/docs/lang/optimizations.md
+++ b/docs/lang/optimizations.md
@@ -6,7 +6,7 @@ OI 界的常用编程语言是 C++。既然使用了这门语言，就注定要�
 
 ### 什么是优化 (Optimization)
 
-根据 [如同规则](https://en.cppreference.com/w/cpp/language/as_if)（The as-if Rule），在保持语义不变的情况下，对程序运行速度、程序可执行文件大小作出改进。
+根据 [如同规则](https://zh.cppreference.com/w/cpp/language/as_if)（The as-if Rule），在保持语义不变的情况下，对程序运行速度、程序可执行文件大小作出改进。
 
 <!-- ### 开优化的比赛有哪些？ -->
 
@@ -226,7 +226,7 @@ int hotpath_again;  // <-- 热！
 
 我们看到后一种布局中，两个热代码块被放到了一起，执行效率更优秀。
 
-为了告诉编译器分支是否容易被执行，可以使用 C++20 `[[likely]]` 和 `[[unlikely]]`:<https://en.cppreference.com/w/cpp/language/attributes/likely>
+为了告诉编译器分支是否容易被执行，可以使用 C++20 `[[likely]]` 和 `[[unlikely]]`:<https://zh.cppreference.com/w/cpp/language/attributes/likely>
 
 如果比赛没有采用 C++20 以上标准，则可以利用 `__builtin_expect`(GNU Extension)。
 
@@ -535,11 +535,11 @@ void test(int* __restrict a, int* __restrict b, int n) {
 
 现代编译器会直接忽略你的 `register` 关键字，你自己认为的寄存器分配一般没有编译器直接跑寄存器分配算法来的聪明。此关键字于 C++11 被弃用，于 C++17 被删除[^p0001r1]。
 
-<https://en.cppreference.com/w/cpp/keyword/register>
+<https://zh.cppreference.com/w/cpp/keyword/register>
 
 ## 未定义行为（Undefined Behavior）与编译优化
 
-编译器可以认为 C++ 程序不存在 [未定义行为](https://en.cppreference.com/w/cpp/language/ub)（undefined behavior，UB），因此在编译存在 UB 的程序时，编译器可能会产生意想不到的结果。同时，编译器也可以在假定不存在 UB 的情况下进行更加激进而自由的优化。
+编译器可以认为 C++ 程序不存在 [未定义行为](https://zh.cppreference.com/w/cpp/language/ub)（undefined behavior，UB），因此在编译存在 UB 的程序时，编译器可能会产生意想不到的结果。同时，编译器也可以在假定不存在 UB 的情况下进行更加激进而自由的优化。
 
 常见的 UB 有：
 

--- a/docs/lang/pointer.md
+++ b/docs/lang/pointer.md
@@ -204,7 +204,7 @@ int main() {
 ```
 
 ???+ note "列表初始化"
-    `{}` 运算符可以用来初始化没有构造函数的结构。除此之外，使用 `{}` 运算符可以使得变量的初始化形式变得统一。详见「[list initialization (since C++11)](https://en.cppreference.com/w/cpp/language/list_initialization)」。
+    `{}` 运算符可以用来初始化没有构造函数的结构。除此之外，使用 `{}` 运算符可以使得变量的初始化形式变得统一。详见「[list initialization (since C++11)](https://zh.cppreference.com/w/cpp/language/list_initialization)」。
 
 需要注意，当使用 `new` 申请的内存不再使用时，需要使用 `delete` 释放这块空间。不能对一块内存释放两次或以上。而对空指针 `nullptr` 使用 `delete` 操作是合法的。
 

--- a/docs/math/number-theory/gcd.md
+++ b/docs/math/number-theory/gcd.md
@@ -118,7 +118,7 @@
 
 上述算法都可被称作欧几里得算法（Euclidean algorithm）。
 
-另外，对于 C++17，我们可以使用 [`<numeric>`](https://en.cppreference.com/w/cpp/header/numeric) 头中的 [`std::gcd`](https://en.cppreference.com/w/cpp/numeric/gcd) 与 [`std::lcm`](https://en.cppreference.com/w/cpp/numeric/lcm) 来求最大公约数和最小公倍数。
+另外，对于 C++17，我们可以使用 [`<numeric>`](https://zh.cppreference.com/w/cpp/header/numeric) 头中的 [`std::gcd`](https://zh.cppreference.com/w/cpp/numeric/gcd) 与 [`std::lcm`](https://zh.cppreference.com/w/cpp/numeric/lcm) 来求最大公约数和最小公倍数。
 
 ???+ warning "注意"
     在部分编译器中，C++14 中可以用 `std::__gcd(a,b)` 函数来求最大公约数，但是其仅作为 `std::rotate` 的私有辅助函数。[^1]使用该函数可能会导致预期之外的问题，故一般情况下不推荐使用。
@@ -204,7 +204,7 @@
 
 ???+ note "关于 countr_zero"
     1.  gcc 有 [内建函数](../../bit/#内建函数) `__builtin_ctz`（32 位）或 `__builtin_ctzll`（64 位）可替换上述代码的 `countr_zero`；
-    2.  从 C++20 开始，头文件 `<bit>` 包含了 [`std::countr_zero`](https://en.cppreference.com/w/cpp/numeric/countr_zero)；
+    2.  从 C++20 开始，头文件 `<bit>` 包含了 [`std::countr_zero`](https://zh.cppreference.com/w/cpp/numeric/countr_zero)；
     3.  如果不使用不在标准库的函数，又无法使用 C++20 标准，下面的代码是一种在 Word-RAM with multiplication 模型下经过预处理后 $O(1)$ 的实现：
     
     ```cpp

--- a/docs/math/numerical/interp.md
+++ b/docs/math/numerical/interp.md
@@ -212,7 +212,7 @@ $$
 
 ## C++ 中的实现
 
-自 C++ 20 起，标准库添加了 [`std::midpoint`](https://en.cppreference.com/w/cpp/numeric/midpoint) 和 [`std::lerp`](https://en.cppreference.com/w/cpp/numeric/lerp) 函数，分别用于求中点和线性插值。
+自 C++ 20 起，标准库添加了 [`std::midpoint`](https://zh.cppreference.com/w/cpp/numeric/midpoint) 和 [`std::lerp`](https://zh.cppreference.com/w/cpp/numeric/lerp) 函数，分别用于求中点和线性插值。
 
 ## 参考资料
 

--- a/docs/math/order-theory.md
+++ b/docs/math/order-theory.md
@@ -273,7 +273,7 @@ Dilworth 定理与 [Hall 婚配定理](../graph/graph-matching/graph-match.md#�
 
 另请参阅：[排序相关 STL -  算法基础](../basic/stl-sort.md)。
 
-C++ STL 中 [需要使用比较的算法和数据结构](https://en.cppreference.com/w/cpp/named_req/Compare#Standard_library) 中有序理论的应用。我们经常需要在 C++ 中自定义比较器，STL [要求](https://en.cppreference.com/w/cpp/named_req/Compare) 其必须为 **严格弱序**。令 $<$ 为自定义比较器，则可以定义：
+C++ STL 中 [需要使用比较的算法和数据结构](https://zh.cppreference.com/w/cpp/named_req/Compare#Standard_library) 中有序理论的应用。我们经常需要在 C++ 中自定义比较器，STL [要求](https://zh.cppreference.com/w/cpp/named_req/Compare) 其必须为 **严格弱序**。令 $<$ 为自定义比较器，则可以定义：
 
 -   $x>y$ 为 $y<x$；
 -   $x \leq y$ 为 $y \nless x$；

--- a/docs/misc/main-element.md
+++ b/docs/misc/main-element.md
@@ -58,7 +58,7 @@ cout << val;
 ???+ warning "注意"
     若原数据中并不存在主元素，则摩尔投票算法给出的结果可能是任意值。此时需要再次遍历一遍数组，统计 `val` 出现次数的最大值，判断是否超过 $\dfrac n 2$。
     
-    另外，为了保证空间复杂度为 $O(1)$，再次遍历数组时可以选择重置输入位置指示器，可利用 [`std::basic_istream<CharT,Traits>::seekg`](https://en.cppreference.com/w/cpp/io/basic_istream/seekg)（流式输入）或 [`rewind`](https://en.cppreference.com/w/c/io/rewind)、[`fseek`](https://en.cppreference.com/w/c/io/fseek)（C 风格输入）等库函数。
+    另外，为了保证空间复杂度为 $O(1)$，再次遍历数组时可以选择重置输入位置指示器，可利用 [`std::basic_istream<CharT,Traits>::seekg`](https://zh.cppreference.com/w/cpp/io/basic_istream/seekg)（流式输入）或 [`rewind`](https://zh.cppreference.com/w/c/io/rewind)、[`fseek`](https://zh.cppreference.com/w/c/io/fseek)（C 风格输入）等库函数。
 
 ## 习题
 


### PR DESCRIPTION
- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。
目前Wiki中对cppreference的引用有气英文界面和简体中文界面，介于 ~强迫症~ OI-Wiki 大多数用户为简体中文用户，建议统一修改为cppreference的简体中文界面，但同时引用资料处为避免歧义不进行修改。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 若本 Pull Request 能够完全解决某个 Issue，请将该 Pull Request 与对应的 Issue 链接起来，具体做法请参见 <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->
