### PR TITLE
fix(math): unify the notation of p-adic valuations

### DIFF
--- a/docs/math/combinatorics/fibonacci.md
+++ b/docs/math/combinatorics/fibonacci.md
@@ -327,13 +327,13 @@ $$
 当 $p$ 是奇素数时，由 [升幂引理](../number-theory/lift-the-exponent.md)，有：
 
 $$
-v_p\left(a^t-1\right)=v_p\left(a-1\right)+v_p(t)
+\nu_p\left(a^t-1\right)=\nu_p\left(a-1\right)+\nu_p(t)
 $$
 
 当 $p=2$ 时，由 [升幂引理](../number-theory/lift-the-exponent.md)，有：
 
 $$
-v_2\left(a^t-1\right)=v_2\left(a-1\right)+v_2\left(a+1\right)+v_2(t)-1
+\nu_2\left(a^t-1\right)=\nu_2\left(a-1\right)+\nu_2\left(a+1\right)+\nu_2(t)-1
 $$
 
 代入 $a$ 为 $\left(\frac{1+\sqrt{5}}{2}\right)$ 和 $\left(\frac{1-\sqrt{5}}{2}\right)$，$t$ 为 $M$ 和 $Mp$，上述条件也就等价于：

--- a/docs/math/number-theory/lift-the-exponent.md
+++ b/docs/math/number-theory/lift-the-exponent.md
@@ -2,7 +2,7 @@
 
 升幂（Lift the Exponent，LTE）引理是初等数论中比较常用的一个定理。
 
-定义 $v_p(n)$ 为整数 $n$ 的标准分解中素因子 $p$ 的幂次，即 $v_p(n)$ 满足 $p^{v_p(n)}\mid n$ 且 $p^{v_p(n)+1}\nmid n$.
+定义 $\nu_p(n)$ 为整数 $n$ 的标准分解中素因子 $p$ 的幂次，即 $\nu_p(n)$ 满足 $p^{\nu_p(n)}\mid n$ 且 $p^{\nu_p(n)+1}\nmid n$.
 
 由于升幂引理内容较长，我们将其分为三部分介绍：
 
@@ -15,13 +15,13 @@
 1.  若 $p\mid x-y$，则：
 
     $$
-    v_p\left(x^n-y^n\right)=v_p(x-y)
+    \nu_p\left(x^n-y^n\right)=\nu_p(x-y)
     $$
 
 2.  若 $p\mid x+y$，则对奇数 $n$ 有：
 
     $$
-    v_p\left(x^n+y^n\right)=v_p(x+y)
+    \nu_p\left(x^n+y^n\right)=\nu_p(x+y)
     $$
 
 ???+ note "证明"
@@ -42,13 +42,13 @@
 1.  若 $p\mid x-y$，则：
 
     $$
-    v_p\left(x^n-y^n\right)=v_p(x-y)+v_p(n)
+    \nu_p\left(x^n-y^n\right)=\nu_p(x-y)+\nu_p(n)
     $$
 
 2.  若 $p\mid x+y$，则对奇数 $n$ 有：
 
     $$
-    v_p\left(x^n+y^n\right)=v_p(x+y)+v_p(n)
+    \nu_p\left(x^n+y^n\right)=\nu_p(x+y)+\nu_p(n)
     $$
 
 ???+ note "证明"
@@ -66,12 +66,12 @@
         从而
     
         $$
-        v_p\left(x^n-y^n\right)=v_p(x-y)+1
+        \nu_p\left(x^n-y^n\right)=\nu_p(x-y)+1
         $$
     -   若 $n=p^a$，则由数学归纳法可得
     
         $$
-        v_p\left(x^n-y^n\right)=v_p(x-y)+a
+        \nu_p\left(x^n-y^n\right)=\nu_p(x-y)+a
         $$
     
     因此命题得证。
@@ -85,38 +85,38 @@
 1.  对奇数 $n$ 有（与第一部分的 1 相同）：
 
     $$
-    v_p\left(x^n-y^n\right)=v_p(x-y)
+    \nu_p\left(x^n-y^n\right)=\nu_p(x-y)
     $$
 
 2.  对偶数 $n$ 有：
 
     $$
-    v_p\left(x^n-y^n\right)=v_p(x-y)+v_p(x+y)+v_p(n)-1
+    \nu_p\left(x^n-y^n\right)=\nu_p(x-y)+\nu_p(x+y)+\nu_p(n)-1
     $$
 
 另外对上述的 $x,y,n$，我们有：
 
 若 $4\mid x-y$，则：
 
--   $v_2(x+y)=1$
--   $v_2\left(x^n-y^n\right)=v_2(x-y)+v_2(n)$
+-   $\nu_2(x+y)=1$
+-   $\nu_2\left(x^n-y^n\right)=\nu_2(x-y)+\nu_2(n)$
 
 ???+ note "证明"
     我们只需证明 $n$ 为偶数的情况。由于此时 $p\nmid \dbinom{p}{2}$，故我们不能用第二部分的方法证明。
     
-    令 $n=2^a b$，其中 $a=v_p(n)$，$2\nmid b$，从而
+    令 $n=2^a b$，其中 $a=\nu_p(n)$，$2\nmid b$，从而
     
     $$
     \begin{aligned}
-        v_p\left(x^n-y^n\right)&=v_p\left(x^{2^a}-y^{2^a}\right)\\
-        &=v_p\left((x-y)(x+y)\prod_{i=1}^{a-1}\left(x^{2^i}+y^{2^i}\right)\right)
+        \nu_p\left(x^n-y^n\right)&=\nu_p\left(x^{2^a}-y^{2^a}\right)\\
+        &=\nu_p\left((x-y)(x+y)\prod_{i=1}^{a-1}\left(x^{2^i}+y^{2^i}\right)\right)
     \end{aligned}
     $$
     
     注意到 $2\mid x-y\implies 4\mid x^2-y^2$，从而 $(\forall i\geq 1),~~x^{2^i}+y^{2^i}\equiv 2\pmod 4$，进而上式可变为：
     
     $$
-    v_p\left(x^n-y^n\right)=v_p(x-y)+v_p(x+y)+v_p(n)-1
+    \nu_p\left(x^n-y^n\right)=\nu_p(x-y)+\nu_p(x+y)+\nu_p(n)-1
     $$
     
     因此命题得证。

--- a/docs/math/number-theory/wilson.md
+++ b/docs/math/number-theory/wilson.md
@@ -123,15 +123,15 @@ $$
 如果想计算二项式系数模 $p$，那么还需要考虑在 $n$ 的阶乘的素因子分解中 $p$ 出现的次数，或在计算修改因子时删除因子 $p$ 的个数。
 
 ???+ note "Legendre 公式"
-    $n!$ 中含有的素数 $p$ 的幂次 $v_p(n!)$ 为：
+    $n!$ 中含有的素数 $p$ 的幂次 $\nu_p(n!)$ 为：
     
     $$
-    v_p(n!) = \sum_{i=1}^{\infty} \left\lfloor \frac{n}{p^i} \right\rfloor = \frac{n-S_p(n)}{p-1}
+    \nu_p(n!) = \sum_{i=1}^{\infty} \left\lfloor \frac{n}{p^i} \right\rfloor = \frac{n-S_p(n)}{p-1}
     $$
     
     其中 $S_p(n)$ 为 $p$ 进制下 $n$ 的各个数位的和。
 
-特别地，阶乘中 2 的幂次是 $v_2(n!)=n-S_2(n)$
+特别地，阶乘中 2 的幂次是 $\nu_2(n!)=n-S_2(n)$
 
 ??? note "证明"
     将 $n!$ 记为 $1\times 2\times \cdots \times p\times \cdots \times 2p\times \cdots \times \lfloor n/p\rfloor p\times \cdots \times n$ 那么其中 $p$ 的倍数有 $p\times 2p\times \cdots \times \lfloor n/p\rfloor p=p^{\lfloor n/p\rfloor }\lfloor n/p\rfloor !$ 然后在 $\lfloor n/p\rfloor !$ 中继续寻找 $p$ 的倍数即可，这是一个递归的过程。
@@ -166,10 +166,10 @@ $$
     即
     
     $$
-    v_p\left(\dbinom{m}{n}\right)=\frac{S_p(n)+S_p(m-n)-S_p(m)}{p-1}
+    \nu_p\left(\dbinom{m}{n}\right)=\frac{S_p(n)+S_p(m-n)-S_p(m)}{p-1}
     $$
 
-特别地，组合数中 $2$ 的幂次是 $v_2\left(\dbinom{m}{n}\right)=S_2(n)+S_2(m-n)-S_2(m)$.
+特别地，组合数中 $2$ 的幂次是 $\nu_2\left(\dbinom{m}{n}\right)=S_2(n)+S_2(m-n)-S_2(m)$.
 
 ## Wilson 定理的推广
 


### PR DESCRIPTION
- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

统一记号 $\nu_p(n)$ 而不是 $v_p(n)$。

参考：https://en.wikipedia.org/wiki/P-adic_valuation

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 若本 Pull Request 能够完全解决某个 Issue，请将该 Pull Request 与对应的 Issue 链接起来，具体做法请参见 <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->
