### PR TITLE
feat(primitive-root.md): 使证明自然一点

### DIFF
--- a/docs/math/number-theory/primitive-root.md
+++ b/docs/math/number-theory/primitive-root.md
@@ -184,21 +184,11 @@ $$
     
     当对于 $\varphi(m)$ 的每个素因数 $p$，都有 $g^{\frac{\varphi(m)}{p}}\not\equiv 1\pmod m$ 成立时，我们假设存在一个 $g$，其不是模 $m$ 的原根。
     
-    因为 $g$ 不是 $m$ 的原根，则存在一个 $t<\varphi(m)$ 使得 $g^t\equiv 1\pmod{m}$.
+    因为 $g$ 不是 $m$ 的原根，且将 $g^{\varphi(m)}\equiv 1\pmod m$ 带入性质二，得到 $g$ 的阶 $\delta_m(g)$ 应满足 $\delta_m(g) \lt \varphi(m)$ 且 $\delta_m(g) \mid \varphi(m)$.
     
-    由 [裴蜀定理](./bezouts.md) 得，一定存在一组 $k,x$ 满足 $kt=x\varphi(m)+(t,\varphi(m))$.
+    故存在 $\varphi(m)$ 的素因数 $p$ 使得 $\delta_m(g) \mid \frac{\varphi(m)}{p}$.
     
-    又由 [欧拉定理](./fermat.md#欧拉定理) 得 $g^{\varphi(m)}\equiv 1\pmod{m}$，故有：
-    
-    $$
-    1\equiv g^{kt}\equiv g^{x\varphi(m)+(t,\varphi(m))}\equiv g^{(t,\varphi(m))}\pmod{m}
-    $$
-    
-    由于 $(t, \varphi(m)) \mid \varphi(m)$ 且 $(t, \varphi(m))\leqslant t < \varphi(m)$.
-    
-    故存在 $\varphi(m)$ 的素因数 $p$ 使得 $(t, \varphi(m)) \mid \frac{\varphi(m)}{p}$.
-    
-    则 $g^{\frac{\varphi(m)}{p}}\equiv g^{(t, \varphi(m))}\equiv 1\pmod{m}$，与条件矛盾。
+    则 $g^{\frac{\varphi(m)}{p}}\equiv g^{\delta_m(g)}\equiv 1\pmod{m}$，与条件矛盾。
     
     故假设不成立，原命题成立。
 


### PR DESCRIPTION


- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 若本 Pull Request 能够完全解决某个 Issue，请将该 Pull Request 与对应的 Issue 链接起来，具体做法请参见 <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->
