### PR TITLE
fix(misc/random.md): 删除关于熵池的错误论述

### DIFF
--- a/docs/misc/random.md
+++ b/docs/misc/random.md
@@ -1,3 +1,4 @@
+author: Kasugan0, StudyingFather, Arielfoever, CCXXXI, Enter-tainer, Henry-ZHR, Ir1d, ksyx, Marcythm, ouuan, partychicken, R-G-Mocoratioen, TianyiQ, Tiphereth-A, Vivian Heleneto, woruo27, Xeonacid
 ## 概述
 
 要想使用随机化技巧，前提条件是能够快速生成随机数。本文将介绍生成随机数的常见方法。
@@ -186,9 +187,7 @@ int main() {
 
 ### 非确定随机数的均匀分布整数随机数生成器
 
-`random_device` 是一个基于硬件的均匀分布随机数生成器，**在熵池耗尽** 前可以高速生成随机数。该类在 C++11 定义，需要 `random` 头文件。由于熵池耗尽后性能急剧下降，所以建议用此方法生成 `mt19937` 等伪随机数的种子，而不是直接生成。
-
-`random_device` 是非确定的均匀随机位生成器，尽管若不支持非确定随机数生成，则允许实现用伪随机数引擎实现。目前笔者尚未接到报告称 NOIP 评测机不支持基于硬件的均匀分布随机数生成。但出于保守考虑，建议使用该算法生成随机数种子。
+`random_device` 是一个基于硬件的均匀分布随机数生成器，可以高速生成随机数。该类在 C++11 定义，需要 `random` 头文件。
 
 参考代码如下。
 
@@ -203,10 +202,7 @@ int main() {
   std::map<int, int> hist;
   std::uniform_int_distribution<int> dist(0, 9);
   for (int n = 0; n < 20000; ++n) {
-    ++hist[dist(rd)];  // 注意：仅用于演示：一旦熵池耗尽，
-                       // 许多 random_device 实现的性能就急剧下滑
-                       // 对于实践使用， random_device 通常仅用于
-                       // 播种类似 mt19937 的伪随机数生成器
+    ++hist[dist(rd)];
   }
   for (auto p : hist) {
     std::cout << p.first << " : " << std::string(p.second / 100, '*') << '\n';

--- a/docs/misc/random.md
+++ b/docs/misc/random.md
@@ -1,4 +1,5 @@
 author: Kasugan0, StudyingFather, Arielfoever, CCXXXI, Enter-tainer, Henry-ZHR, Ir1d, ksyx, Marcythm, ouuan, partychicken, R-G-Mocoratioen, TianyiQ, Tiphereth-A, Vivian Heleneto, woruo27, Xeonacid
+
 ## 概述
 
 要想使用随机化技巧，前提条件是能够快速生成随机数。本文将介绍生成随机数的常见方法。


### PR DESCRIPTION
- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 若本 Pull Request 能够完全解决某个 Issue，请将该 Pull Request 与对应的 Issue 链接起来，具体做法请参见 <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->

此部分关于熵池的论述是过时的，甚至有些是有误的，应当被移除。这部分内容为 `random_device` 使用者增加了额外且不必要的负担。

下面我将展开详细的论述。

### `/dev/urandom` 和 `/dev/random`

`/dev/urandom`  是非阻塞的一个高质量随机数生成器。在熵池耗尽前，生成真随机数；在熵池耗尽之后，生成伪随机数。在 Linux 2.6 （发布于 2003 年）之后，性能和质量已经足够的高，可以胜任密码学级别的随机性。

`/dev/random` 从熵池中生成真随机数，但是阻塞的。存在 0241a25 和 9bb8bcc 提到的的熵池阻塞问题。

对于非 Linux，请见 [StackExchange 上一个简短的解释](https://unix.stackexchange.com/questions/324209/when-to-use-dev-random-vs-dev-urandom)。

###  C++ 标准库的实现

从 GCC 4.8 版本开始，`std::random_device` 的默认实现就是使用 `/dev/urandom`。

从 Clang 3.4 版本开始，`std::random_device` 的默认实现也是使用 `/dev/urandom`。

这说明  0241a25 和 9bb8bcc 提到的的熵池阻塞问题在现代操作系统上根本不存在。_就连 NOI Linux 都使用了 GCC 9.3.0。_

### 一些检查

使用 `strace` 命令检查，系统调用是  `/dev/urandom` 而非  `/dev/random`。

对于 GCC，请检查 `bits/random.h` 文件中的实现。
对于 Clang，请检查 `include/random` 文件中的实现。
两者都为 `/dev/urandom`。

### 「可是我就是想用 `/dev/random`」

你可以尝试直接从 `/dev/random` 文件中读取一定 Byte 的二进制数字。

----

综上所述，「熵池阻塞」问题在现代系统上使用 `std::random_device` 时根本不会出现。应当删去相关内容。
