### PR TITLE
fix(bplus-tree.md): B+删除代码部分，在进行合并节点时，拷贝有误 (#6166)

### DIFF
--- a/docs/ds/bplus-tree.md
+++ b/docs/ds/bplus-tree.md
@@ -687,6 +687,7 @@ B+ 树的删除也仅在叶子节点中进行，当叶子节点中的最大关�
         removeInternal(parent->key[rightSibling - 1], parent, rightNode);
       }
     }
+    ```
 
     void BPTree::display(Node *cursor) {
       if (cursor != NULL) {

--- a/docs/ds/bplus-tree.md
+++ b/docs/ds/bplus-tree.md
@@ -703,7 +703,7 @@ B+ 树的删除也仅在叶子节点中进行，当叶子节点中的最大关�
     }
     
     Node *BPTree::getRoot() { return root; }
-
+    
     int main() {
       BPTree node;
       node.insert(5);

--- a/docs/ds/bplus-tree.md
+++ b/docs/ds/bplus-tree.md
@@ -687,8 +687,7 @@ B+ 树的删除也仅在叶子节点中进行，当叶子节点中的最大关�
         removeInternal(parent->key[rightSibling - 1], parent, rightNode);
       }
     }
-    ```
-
+    
     void BPTree::display(Node *cursor) {
       if (cursor != NULL) {
         for (int i = 0; i < cursor->size; i++) {
@@ -702,7 +701,7 @@ B+ 树的删除也仅在叶子节点中进行，当叶子节点中的最大关�
         }
       }
     }
-
+    
     Node *BPTree::getRoot() { return root; }
 
     int main() {
@@ -712,11 +711,11 @@ B+ 树的删除也仅在叶子节点中进行，当叶子节点中的最大关�
       node.insert(25);
       node.insert(35);
       node.insert(45);
-
+    
       node.display(node.getRoot());
-
+    
       node.remove(15);
-
+    
       node.display(node.getRoot());
     }
     ```

--- a/docs/ds/bplus-tree.md
+++ b/docs/ds/bplus-tree.md
@@ -662,10 +662,10 @@ B+ 树的删除也仅在叶子节点中进行，当叶子节点中的最大关�
       if (leftSibling >= 0) {
         Node *leftNode = parent->ptr[leftSibling];
         leftNode->key[leftNode->size] = parent->key[leftSibling];
-        for (int i = leftNode->size + 1, j = 0; j < cursor->size; j++) {
+        for (int i = leftNode->size + 1, j = 0; j < cursor->size; i++, j++) {
           leftNode->key[i] = cursor->key[j];
         }
-        for (int i = leftNode->size + 1, j = 0; j < cursor->size + 1; j++) {
+        for (int i = leftNode->size + 1, j = 0; j < cursor->size + 1; i++, j++) {
           leftNode->ptr[i] = cursor->ptr[j];
           cursor->ptr[j] = NULL;
         }
@@ -675,10 +675,10 @@ B+ 树的删除也仅在叶子节点中进行，当叶子节点中的最大关�
       } else if (rightSibling <= parent->size) {
         Node *rightNode = parent->ptr[rightSibling];
         cursor->key[cursor->size] = parent->key[rightSibling - 1];
-        for (int i = cursor->size + 1, j = 0; j < rightNode->size; j++) {
+        for (int i = cursor->size + 1, j = 0; j < rightNode->size; i++, j++) {
           cursor->key[i] = rightNode->key[j];
         }
-        for (int i = cursor->size + 1, j = 0; j < rightNode->size + 1; j++) {
+        for (int i = cursor->size + 1, j = 0; j < rightNode->size + 1; i++, j++) {
           cursor->ptr[i] = rightNode->ptr[j];
           rightNode->ptr[j] = NULL;
         }

--- a/docs/ds/bplus-tree.md
+++ b/docs/ds/bplus-tree.md
@@ -1,4 +1,4 @@
-author: Persdre, jaking
+author: Persdre
 
 ## 引入
 

--- a/docs/ds/bplus-tree.md
+++ b/docs/ds/bplus-tree.md
@@ -1,4 +1,4 @@
-author: Persdre
+author: Persdre, jaking
 
 ## 引入
 
@@ -682,6 +682,7 @@ B+ 树的删除也仅在叶子节点中进行，当叶子节点中的最大关�
           cursor->ptr[i] = rightNode->ptr[j];
           rightNode->ptr[j] = NULL;
         }
+
         cursor->size += rightNode->size + 1;
         rightNode->size = 0;
         removeInternal(parent->key[rightSibling - 1], parent, rightNode);

--- a/docs/ds/bplus-tree.md
+++ b/docs/ds/bplus-tree.md
@@ -682,8 +682,6 @@ B+ 树的删除也仅在叶子节点中进行，当叶子节点中的最大关�
           cursor->ptr[i] = rightNode->ptr[j];
           rightNode->ptr[j] = NULL;
         }
-    ```
-
         cursor->size += rightNode->size + 1;
         rightNode->size = 0;
         removeInternal(parent->key[rightSibling - 1], parent, rightNode);


### PR DESCRIPTION
- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 若本 Pull Request 能够完全解决某个 Issue，请将该 Pull Request 与对应的 Issue 链接起来，具体做法请参见 <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->
在B+树removeInternal中，当左右兄弟都不够借用时，需要进行合并。在合并时，拷贝数据出现问题，i未++导致数据拷贝至同一位置。代码位于403行至420行。
issue:https://github.com/OI-wiki/OI-wiki/issues/6166#issue-2931891047

