### PR TITLE
fix(check-characters.yml): 设置 `fetch-depth` 避免 git 记录不完整

### DIFF
--- a/.github/workflows/check-characters.yml
+++ b/.github/workflows/check-characters.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v46


### PR DESCRIPTION
> 可以看一下这个 failed 的 actions 吗，似乎是和 `tj-actions/changed-files` 相关的。
> 我搜索了一下，只有这个 actions 在 checkout 的时候没有加 `fetch-depth: 0`，是否和这个问题有关。`actions/checkout` 对这一项的描述是：
> ```yaml
>     # Number of commits to fetch. 0 indicates all history for all branches and tags.
>     # Default: 1
>     fetch-depth: ''
> ```
> _最初由 @HeRaNO 在 https://github.com/OI-wiki/OI-wiki/pull/6174#issuecomment-2750314457 发布_

在使用 `tj-actions/changed-files` 并开启 `since_last_remote_commit` 时，设置 `fetch-depth` 为 `1` 并不总能满足需求，尽管在 `tj-actions/changed-files` 的 README 中并没有进行任何强调或暗示。

但实际上，Checkout 正在检查 PR HEAD 和基本分支的合并，`fetch-depth` 在这种情况下不能达到预期效果。具体相关问题可参考 actions/checkout#881 。

虽然直接获取完整 git 记录（设置 `fetch-depth` 为 `0`）是一种可行的解决方案，本 PR 设置其为 `2` 并将 `sha` 设置为 `${{ github.event.pull_request.head.sha }}`，以达到最高的运行效率。

ref: https://github.com/tj-actions/changed-files/discussions/1549#discussioncomment-6950488