### PR TITLE
feat(scripts/post-build/math): add MathJax MathML output back

### DIFF
--- a/scripts/post-build/math/task-handler.ts
+++ b/scripts/post-build/math/task-handler.ts
@@ -7,6 +7,7 @@ import { HTMLElement } from "node-html-parser";
 import { mathjax } from "mathjax-full/js/mathjax.js";
 import { TeX } from "mathjax-full/js/input/tex.js";
 import { CHTML } from "mathjax-full/js/output/chtml.js";
+import { AssistiveMmlHandler } from "mathjax-full/js/a11y/assistive-mml.js";
 import { LiteAdaptor, liteAdaptor } from "mathjax-full/js/adaptors/liteAdaptor.js";
 import { HTMLHandler } from "mathjax-full/js/handlers/html/HTMLHandler.js";
 import { SafeHandler } from "mathjax-full/js/ui/safe/SafeHandler.js";
@@ -70,7 +71,9 @@ export class MathRenderer {
       adaptiveCSS: false
     });
 
-    mathjax.handlers.register(SafeHandler(new HTMLHandler(this.adaptor)));
+    const handler = SafeHandler(new HTMLHandler(this.adaptor));
+    mathjax.handlers.register(handler);
+    AssistiveMmlHandler(handler);
 
     this.document = mathjax.document("", {
       InputJax: inputJax,


### PR DESCRIPTION
To improve a11y and make visitors can control math style if they want.

Recommend to read "Is MathML accessible?"[^1] by Peter Krautzberger (who is the maintainer of MathJax and participated in the research and development of many mathematics-related Web standards.), Presentation MathML is not the prefect solution of math accessibility, but it's the best one we have, and many people are working on improving it. Content MathML is better for a11y, but a well-written Presentation MathML can reach the same level as well, and Content MathML support is really really poor, especially in browsers (Maybe zero, I think.). MathJax exactly is the right tool to get well-written Presentation MathML.

For later usage, please use Native MathML extension[^2][^3], or use CSS below:
```css
/* SPDX-License-Identifier: MPL-2.0 */
/* Hide MathJax's own output when MathML existed. */
mjx-container:has(mjx-assistive-mml) mjx-math {
	display: none !important;
}
mjx-container:has(mjx-assistive-mml) svg {
	display: none !important;
}

/* Reset properties set on the assistive MathML, so that it shows up. */
mjx-container > mjx-assistive-mml {
	display: inline !important;
	position: revert !important;
	clip: revert;
	top: revert;
	left: revert;
	padding: revert;
	border: revert !important;
	overflow: revert !important;
	-webkit-touch-callout: revert;
	-webkit-user-select: revert;
	-khtml-user-select: revert;
	-moz-user-select: revert;
	-ms-user-select: revert;
	user-select: revert;
}
mjx-container > mjx-assistive-mml[display="block"] {
	display: block !important;
}
```

Native MathML also covered math expressions on KaTeX, MathJax 2 (use js to modify cookies) or Mediawiki, but it has an issue: If a MathJax 3 website disabled AssistiveMml, it will display blank for math expression.[^4] I fix it in code above, but I can't contribute back because :has() was supported since Chromium 105 (2022-09-02) and Firefox 121 (2023-12-19).

[^1]: https://www.peterkrautzberger.org/0185/
[^2]: https://addons.mozilla.org/en-US/firefox/addon/native-mathml/
[^3]: https://chromewebstore.google.com/detail/native-mathml/lcadkfljmcmcflpdbfmgcpjlejmpcplg
[^4]: https://github.com/fred-wang/webextension-native-mathml/issues/21

I tweaked the cover letter to improve the reading experience on GitHub, so please use 'rebase merge' to keep the merged commit message with a good plaintext experience.

- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 若本 Pull Request 能够完全解决某个 Issue，请将该 Pull Request 与对应的 Issue 链接起来，具体做法请参见 <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->
