### PR TITLE
纠错：文中写作 t-1，应为 t+1（因为等式右侧包含的质数应该更少）

### DIFF
--- a/docs/math/number-theory/zhou.md
+++ b/docs/math/number-theory/zhou.md
@@ -76,7 +76,7 @@ $l$ 共有 $\sqrt n$ 级别种取值，所以直接转移复杂度为 $\displays
 
 与 $g$ 的优化方式类似，注意到 $p_t>l$ 时，能用 $p_t,p_{t+1},\dots,p_m$ 组成的数只有 $1$，此时的 $h(t,l)=f(1)=1$。
 
-类似的，推出 $\forall p_t^2>l,h(t,l)=h(t-1,l)+f(p_t)$。
+类似的，推出 $\forall p_t^2>l,h(t,l)=h(t+1,l)+f(p_t)$。
 
 所以一旦发现 $p_t^2>l$ 就停止转移，记此时的 $t$ 为 $t_l$，之后用到 $h$ 时，把此时的 $h$ 值加上 $\displaystyle\sum_{i=p_{t_l}}^{\min(l,\sqrt n)}[i\in\mathbb P]f(i)$ 即可。
 


### PR DESCRIPTION
- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 若本 Pull Request 能够完全解决某个 Issue，请将该 Pull Request 与对应的 Issue 链接起来，具体做法请参见 <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->
