### PR TITLE
fix(lint_pr_title.yml, remove_labels.yml): 通过 `pull_request_target` 触发需交互 PR 的工作流

### DIFF
--- a/.github/workflows/lint_pr_title.yml
+++ b/.github/workflows/lint_pr_title.yml
@@ -2,7 +2,7 @@
 # Changed By Alphagocc
 name: Lint PR Title
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize]
 
 permissions:

--- a/.github/workflows/remove-labels.yml
+++ b/.github/workflows/remove-labels.yml
@@ -1,7 +1,7 @@
 name: Remove Labels on PR Merge
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 permissions:
@@ -13,9 +13,8 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v8
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const labelsRemoved = [
               'More details needed / 内容需增修',


### PR DESCRIPTION
为使工作流获得与 PR 交互所需的写入权限，此修改将 `lint_pr_title.yml` 和 `remove_labels.yml` 两个工作流的触发事件从 `pull_request` 更改为 `pull_request_target`。

出于安全性考量，GitHub 为工作流触发提供了 `pull_request` 和 `pull_request_target` 事件。原使用的 `pull_request` 事件触发的工作流只能获得权限受限的 `GITHUB_TOKEN`，无法向部分 PR 写入数据；而 `on: pull_request_target` 的工作流则拥有写入权限，从而才能成功执行评论和修改标签等操作。

此修改符合 GitHub Actions 使用习惯，如 `actions/github-script` 的 README 示例 Welcome a first-time contributor 明确需使用 `on: pull_request_target`。

此修改调整的工作流均具有较高安全性，主要得益于以下两点：
1. 无代码检出与执行风险：工作流均未执行 Checkout 步骤，完全不拉取 PR 中的代码，从根本上避免潜在恶意代码在基仓库的信任环境中执行的风险。
2. 最小安全信息访问：工作流仅直接或间接通过 GitHub 官方提供的交互库读取 PR 元数据，未主动获取其它数据。