### PR TITLE
ci: 在构建HTML的时候引入存档链接

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Download data.json
+        run: wget https://github.com/jyeric/OI-wiki/raw/refs/heads/archiveLink/data.json
+        working-directory: scripts/post-build/archive-link
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
@@ -46,7 +49,7 @@ jobs:
           uv run mkdocs build -v
       - name: Post-process HTML
         # https://github.com/TypeStrong/ts-node/issues/1997
-        run: node --loader ts-node/esm scripts/post-build/html-postprocess.ts commits-info math external-links
+        run: node --loader ts-node/esm scripts/post-build/html-postprocess.ts commits-info math external-links archive-link
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_OPTIONS: --max_old_space_size=3072

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "cross-env": "^7.0.3",
     "klaw": "^4.0.1",
     "node-fetch": "^3.2.8",
-    "node-html-parser": "^5.3.3",
+    "node-html-parser": "7.0.1",
     "octokit": "^4.0.2",
     "oiwiki-feedback-sys-frontend": "^0.5.13",
     "patch-package": "^6.5.1",

--- a/scripts/post-build/archive-link/task-handler.ts
+++ b/scripts/post-build/archive-link/task-handler.ts
@@ -34,7 +34,7 @@ export const taskHandler = new (class implements TaskHandler<void> {
       if (archiveUrl == null) return;
 
       let archivedA = null;
-      if (data[link]["status"] != 0) {
+      if (data[link]["fail"] == false) {
         archivedA = new HTMLElement("a", {}, "[存档]");
         archivedA.setAttribute("href", archiveUrl);
         archivedA.setAttribute("target", "_blank");

--- a/scripts/post-build/archive-link/task-handler.ts
+++ b/scripts/post-build/archive-link/task-handler.ts
@@ -1,0 +1,62 @@
+import { HTMLElement } from "node-html-parser";
+import { TaskHandler } from "../html-postprocess.js";
+import * as fs from "fs";
+import * as path from "path";
+
+
+// 读取data.json
+function getArchiveLinkMap(jsonPath: string): Record<string, any> {
+  try {
+    const raw = fs.readFileSync(jsonPath, "utf8");
+    return JSON.parse(raw);
+  } catch (e) {
+    console.error("读取data.json失败", e);
+    return {};
+  }
+}
+
+const archiveLinkData = getArchiveLinkMap("scripts\\post-build\\archive-link\\data.json");
+
+export const taskHandler = new (class implements TaskHandler<void> {
+  async process(document: HTMLElement) {
+    const data = archiveLinkData;
+
+    document.getElementsByTagName("a").forEach(element => {
+      // 检查a标签是否包裹图片
+      const hasImg = element.querySelector && element.querySelector("img");
+      if (hasImg) return;
+
+      const link = element.getAttribute("href");
+      if (!link || !data[link]) return;
+
+      const archiveUrl = data[link]["archiveLink"]
+
+      if (archiveUrl == null) return;
+
+      let archivedA = null;
+      if (data[link]["status"] != 0) {
+        archivedA = new HTMLElement("a", {}, "[存档]");
+        archivedA.setAttribute("href", archiveUrl);
+        archivedA.setAttribute("target", "_blank");
+        archivedA.setAttribute("rel", "noopener noreferrer");
+        archivedA.set_content("[存档]");
+      }
+      else {
+        archivedA = new HTMLElement("a", {}, "[原链]");
+        archivedA.setAttribute("href", link);
+        archivedA.setAttribute("target", "_blank");
+        archivedA.setAttribute("rel", "noopener noreferrer");
+        archivedA.set_content("[原链]");
+        element.setAttribute("href", archiveUrl);
+      }
+      
+
+      // 构造sup
+      const sup = new HTMLElement("sup", {}, "");
+      sup.appendChild(archivedA);
+
+      // 插入sup到a标签后
+      element.after(sup);
+    });
+  }
+})();

--- a/scripts/post-build/archive-link/task-handler.ts
+++ b/scripts/post-build/archive-link/task-handler.ts
@@ -15,7 +15,7 @@ function getArchiveLinkMap(jsonPath: string): Record<string, any> {
   }
 }
 
-const archiveLinkData = getArchiveLinkMap("scripts\\post-build\\archive-link\\data.json");
+const archiveLinkData = getArchiveLinkMap("scripts/post-build/archive-link/data.json");
 
 export const taskHandler = new (class implements TaskHandler<void> {
   async process(document: HTMLElement) {

--- a/scripts/post-build/html-postprocess.ts
+++ b/scripts/post-build/html-postprocess.ts
@@ -7,7 +7,7 @@ import { parse, HTMLElement } from "node-html-parser";
 import klaw from "klaw";
 import chalk from "chalk";
 
-const TASKS = ["commits-info", "math", "external-links"];
+const TASKS = ["commits-info", "math", "external-links", "archive-link"];
 const SITE_DIR = "site";
 
 const siteDir = path.resolve(SITE_DIR);

--- a/yarn.lock
+++ b/yarn.lock
@@ -854,7 +854,7 @@ binary-extensions@^2.0.0:
 
 boolbase@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
+  resolved "https://registry.npmmirror.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
 bottleneck@^2.15.3:
@@ -1084,21 +1084,21 @@ cross-spawn@^7.0.1:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-css-select@^4.2.1:
-  version "4.3.0"
-  resolved "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz"
-  integrity sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==
+css-select@^5.1.0:
+  version "5.2.2"
+  resolved "https://registry.npmmirror.com/css-select/-/css-select-5.2.2.tgz#01b6e8d163637bb2dd6c982ca4ed65863682786e"
+  integrity sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==
   dependencies:
     boolbase "^1.0.0"
-    css-what "^6.0.1"
-    domhandler "^4.3.1"
-    domutils "^2.8.0"
+    css-what "^6.1.0"
+    domhandler "^5.0.2"
+    domutils "^3.0.1"
     nth-check "^2.0.1"
 
-css-what@^6.0.1:
-  version "6.1.0"
-  resolved "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz"
-  integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
+css-what@^6.1.0:
+  version "6.2.2"
+  resolved "https://registry.npmmirror.com/css-what/-/css-what-6.2.2.tgz#cdcc8f9b6977719fdfbd1de7aec24abf756b9dea"
+  integrity sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==
 
 data-uri-to-buffer@^4.0.0:
   version "4.0.0"
@@ -1141,35 +1141,35 @@ diff@^5.0.0:
   resolved "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz"
   integrity sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==
 
-dom-serializer@^1.0.1:
-  version "1.4.1"
-  resolved "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz"
-  integrity sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==
+dom-serializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmmirror.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
+  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
   dependencies:
-    domelementtype "^2.0.1"
-    domhandler "^4.2.0"
-    entities "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    entities "^4.2.0"
 
-domelementtype@^2.0.1, domelementtype@^2.2.0:
+domelementtype@^2.3.0:
   version "2.3.0"
-  resolved "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz"
+  resolved "https://registry.npmmirror.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
   integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
 
-domhandler@^4.2.0, domhandler@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz"
-  integrity sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==
+domhandler@^5.0.2, domhandler@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.npmmirror.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
+  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
   dependencies:
-    domelementtype "^2.2.0"
+    domelementtype "^2.3.0"
 
-domutils@^2.8.0:
-  version "2.8.0"
-  resolved "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz"
-  integrity sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==
+domutils@^3.0.1:
+  version "3.2.2"
+  resolved "https://registry.npmmirror.com/domutils/-/domutils-3.2.2.tgz#edbfe2b668b0c1d97c24baf0f1062b132221bc78"
+  integrity sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==
   dependencies:
-    dom-serializer "^1.0.1"
-    domelementtype "^2.2.0"
-    domhandler "^4.2.0"
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
 
 eastasianwidth@^0.2.0:
   version "0.2.0"
@@ -1186,10 +1186,10 @@ emoji-regex@^9.2.2:
   resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
 
-entities@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz"
-  integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
+entities@^4.2.0:
+  version "4.5.0"
+  resolved "https://registry.npmmirror.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
+  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
 error-ex@^1.3.2:
   version "1.3.2"
@@ -1360,7 +1360,7 @@ hastscript@^7.0.2:
 
 he@1.2.0:
   version "1.2.0"
-  resolved "https://registry.npmjs.org/he/-/he-1.2.0.tgz"
+  resolved "https://registry.npmmirror.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
 ignore@^5.0.0:
@@ -2396,12 +2396,12 @@ node-fetch@^3.2.8:
     fetch-blob "^3.1.4"
     formdata-polyfill "^4.0.10"
 
-node-html-parser@^5.3.3:
-  version "5.3.3"
-  resolved "https://registry.npmjs.org/node-html-parser/-/node-html-parser-5.3.3.tgz"
-  integrity sha512-ncg1033CaX9UexbyA7e1N0aAoAYRDiV8jkTvzEnfd1GDvzFdrsXLzR4p4ik8mwLgnaKP/jyUFWDy9q3jvRT2Jw==
+node-html-parser@7.0.1:
+  version "7.0.1"
+  resolved "https://registry.npmmirror.com/node-html-parser/-/node-html-parser-7.0.1.tgz#e3056550bae48517ebf161a0b0638f4b0123dfe3"
+  integrity sha512-KGtmPY2kS0thCWGK0VuPyOS+pBKhhe8gXztzA2ilAOhbUbxa9homF1bOyKvhGzMLXUoRds9IOmr/v5lr/lqNmA==
   dependencies:
-    css-select "^4.2.1"
+    css-select "^5.1.0"
     he "1.2.0"
 
 normalize-path@^3.0.0, normalize-path@~3.0.0:
@@ -2411,7 +2411,7 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
 
 nth-check@^2.0.1:
   version "2.1.1"
-  resolved "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz"
+  resolved "https://registry.npmmirror.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
   integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
   dependencies:
     boolbase "^1.0.0"


### PR DESCRIPTION
- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 若本 Pull Request 能够完全解决某个 Issue，请将该 Pull Request 与对应的 Issue 链接起来，具体做法请参见 <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->
（合并需等待存档链接data.json合并入OI-wiki仓库）

代码外改动：更新了node-html-parser到7.0.1，因为使用了新版本的.after方法。

主要效果：在每个外部链接的右上方添加存档或原链（当原链接失败时）

示例：<sup>[存档](https://www.example.com)</sup>或<sup>[原链](https://www.example.com)</sup>

网站处理后效果：
https://github.com/jyeric/OI-wiki/releases/tag/test-0.0.0 （单次检测访问失败则视为失败版本）
https://github.com/jyeric/OI-wiki/releases/tag/test-0.0.1 （三次检测失访问败则视为失败版本，由于现在脚本还未到三次，因此该版本不存在替换原链接）