### PR TITLE
fix(quad-residue.md): clarify Gauss's lemma & add generalization

### DIFF
--- a/docs/math/number-theory/quad-residue.md
+++ b/docs/math/number-theory/quad-residue.md
@@ -211,7 +211,7 @@ author: hly1204, ShaoChenHeng, Chrogeek, Enter-tainer, Great-designer, iamtwz, m
     \left(\frac{n}{p}\right)=(-1)^{|J|},
     $$
     
-    其中 $J=\{j\in I:aj\in -I\}$.
+    其中 $J=\{j\in I:nj\in -I\}$.
     
     不难发现取 $I=\{1,2,\dots,(p-1)/2\}$ 即可得到 Gauss 引理。证明方法和 Gauss 引理的证明基本相同，故省略。
 


### PR DESCRIPTION
- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

因为翻译问题导致容易混淆，所以明确一下所谓的「最小非负剩余」就是「最小非负余数」，顺便补一个推广。

放一下部分原文（in German）：

> **Satz**. Es sei $p$ eine positive Primzahl, $k$ eine beliebige durch $p$ nicht teilbare ganze Zahl,
> 
> $A$ der Complex der Zahlen $1, 2, 3, \dots, \frac{1}{2}(p-1)$,
> 
> $B$ der Complex der Zahlen $\frac{1}{2}(p+1), \frac{1}{2}(p+3), \frac{1}{2}(p+5), \dots, p-1$.
> 
> Man nehme ferner die kleinsten positiven Reste der Producte aus $k$ und den einzelnen Zahlen $A$ nach dem Modul $p$, welche offenbar sämtlich verschieden sein und teils zu $A$ teils zu $B$ gehören werden. Nimmt man nun an, dass zu B im Ganzen $\mu$ Reste gehören, so wird $k$ quadratischer Rest oder Nichtrest von $p$ sein, je nachdem $\mu$ gerade oder ungerade ist.

可以看到「$nk$ 模 $p$ 的最小非负 **剩余**」对应的是「Man nehme ferner die kleinsten positiven **Reste** der Producte aus $k$ und den einzelnen Zahlen $A$ nach dem Modul $p$」这一段，「二次 **剩余**」对应的是 「quadratischer **Rest**」。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 若本 Pull Request 能够完全解决某个 Issue，请将该 Pull Request 与对应的 Issue 链接起来，具体做法请参见 <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->
