### PR TITLE
fix: add author check to suggest-pr-reopen workflow

### DIFF
--- a/.github/workflows/suggest-pr-reopen.yml
+++ b/.github/workflows/suggest-pr-reopen.yml
@@ -21,6 +21,14 @@ jobs:
             const createdAt = new Date(pr.created_at);
             const closedAt = new Date(pr.closed_at);
             const diffMinutes = (closedAt - createdAt) / (1000 * 60);
+            const authorLogin = pr.user?.login;
+            const closedByLogin = pr.closed_by?.login ?? context.actor;
+
+            if (closedByLogin !== authorLogin) {
+              core.info('PR was closed by someone other than the author. Skip suggestion.');
+              return;
+            }
+
             if (diffMinutes <= 60) {
               const branchLink = `https://github.com/${pr.head.repo.full_name}/tree/${pr.head.ref}`;
               const body = [


### PR DESCRIPTION
## Summary
- add verification that a PR was closed by its author before posting quick-reopen suggestion
- skip commenting when someone else closes the PR

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f41ac16a48330bc6e29d395a84678)