### PR TITLE
fix(math/combinatorics/derangement.md): 修正容斥原理对错位排列数的计算 (#6761)

### DIFF
--- a/docs/math/combinatorics/derangement.md
+++ b/docs/math/combinatorics/derangement.md
@@ -12,13 +12,13 @@
 
 $$
 \begin{aligned}
-|\bigcap_{i=1}^n S_i|
+\left|\bigcap_{i=1}^n S_i\right|
 &=|U|-\left|\bigcup_{i=1}^n\overline{S_i}\right|\\
 &=n!-\sum_{k=1}^n(-1)^{k-1}\sum_{a_i<a_{i+1}}\left|\bigcap_{i=1}^{k}\overline{S_{a_i}}\right|
 \end{aligned}
 $$
 
-其中
+其中求和的含义是 $1, 2, \cdots, n$ 中取 $a_1, a_2, \cdots, a_k$ 且满足 $a_i<a_{i+1}$．于是
 
 $$
 \left|\bigcap_{i=1}^{k}\overline{S_{a_i}}\right|
@@ -41,7 +41,7 @@ $$
 \end{aligned}
 $$
 
-因此 $n$ 的错位排列数为：
+因此 $n$ 个元素的错位排列数为：
 
 $$
 D_n=n!-n!\sum_{k=1}^n\frac{(-1)^{k-1} }{k!}=n!\sum_{k=0}^n\frac{(-1)^k}{k!}


### PR DESCRIPTION
- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 若本 Pull Request 能够完全解决某个 Issue，请将该 Pull Request 与对应的 Issue 链接起来，具体做法请参见 <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->

本PR解决了 #6761 中的问题，即错位排列的容斥原理列式错误，优化了叙述方式使其自然连贯。