### PR TITLE
fix(graph/virtual-tree.md): 修正了示例代码的 typo；提醒两个做法的复杂度相同

### DIFF
--- a/docs/graph/virtual-tree.md
+++ b/docs/graph/virtual-tree.md
@@ -1,4 +1,4 @@
-author: HeRaNO, Ir1d, konnyakuxzy, ksyx, Xeonacid, konnyakuxzy, greyqz, sshwy
+author: HeRaNO, Ir1d, konnyakuxzy, ksyx, Xeonacid, konnyakuxzy, greyqz, sshwy, y-kx-b
 
 ## 引入
 
@@ -222,6 +222,8 @@ void build_virtual_tree() {
 
 其中有很多细节，比如用邻接表存图的方式存虚树的话，需要清空邻接表．但是直接清空整个邻接表是很慢的，所以我们在 **有一个从未入栈的元素入栈的时候清空该元素对应的邻接表** 即可．
 
+时间复杂度同样为 $O(m\log n)$（因为有排序），其中 $m$ 为关键点数，$n$ 为总点数．
+
 #### 实现
 
 建立虚树的 C++ 代码大概长这样：
@@ -233,14 +235,14 @@ void build_virtual_tree() {
     void build() {
       sort(h + 1, h + k + 1, cmp);
       sta[top = 1] = 1, g.sz = 0, g.head[1] = -1;
-      // 1 号节点入栈，清空 1 号节点对应的邻接表，设置邻接表边数为 1
+      // 1 号节点入栈，清空 1 号节点对应的邻接表，设置邻接表边数为 0
       for (int i = 1, l; i <= k; ++i)
         if (h[i] != 1) {
           // 如果 1 号节点是关键节点就不要重复添加
           l = lca(h[i], sta[top]);
           // 计算当前节点与栈顶节点的 LCA
           if (l != sta[top]) {
-            // 如果 LCA 和栈顶元素不同，则说明当前节点不再当前栈所存的链上
+            // 如果 LCA 和栈顶元素不同，则说明当前节点不在当前栈所存的链上
             while (id[l] < id[sta[top - 1]])
               // 当次大节点的 Dfs 序大于 LCA 的 Dfs 序
               g.push(sta[top - 1], sta[top]), top--;


### PR DESCRIPTION
1. 虽然我不知道 `g` 的实现，但 `g.sz = 0` 肯定不是将边数设置为 1（也没有必要这么做）。
2. 初学者容易先入为主认为单调栈做法就是 $O(n)$ 建树的，但实际上其理论复杂度和第一种做法是相同的（容易忘掉排序），只是常数更小，望引起提醒。 
- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 若本 Pull Request 能够完全解决某个 Issue，请将该 Pull Request 与对应的 Issue 链接起来，具体做法请参见 <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->
