### PR TITLE
fix(graph/dynamic-tree-divide): 修改成了正确的判 -1 的方式

### DIFF
--- a/docs/graph/code/dynamic-tree-divide/dynamic-tree-divide_1.cpp
+++ b/docs/graph/code/dynamic-tree-divide/dynamic-tree-divide_1.cpp
@@ -137,10 +137,11 @@ int main() {
   for (int i = 1; i <= n; i++)
     for (int j = i; j; j = fa[j]) d[i][dep[i] - dep[j]] = lca.dist(i, j);
   cin >> m;
+  int cnt = n;
   while (m--) {
     cin >> op;
     if (op == 'G') {
-      if (ans.size())
+      if (cnt)
         cout << ans.top() << '\n';
       else
         cout << "-1\n";
@@ -159,6 +160,7 @@ int main() {
           if (ch[fa[i]].size() >= 2)
             ans.insert(ch[fa[i]].top() + ch[fa[i]].top2());
         }
+        cnt--;
       } else {
         if (ch[x].size() >= 2) ans.erase(ch[x].top() + ch[x].top2());
         ch[x].insert(0);
@@ -172,6 +174,7 @@ int main() {
           if (ch[fa[i]].size() >= 2)
             ans.insert(ch[fa[i]].top() + ch[fa[i]].top2());
         }
+        cnt++;
       }
       col[x] ^= 1;
     }


### PR DESCRIPTION
判了 -1 的情况，现在可以在洛谷模版题上通过

- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 若本 Pull Request 能够完全解决某个 Issue，请将该 Pull Request 与对应的 Issue 链接起来，具体做法请参见 <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->
