### PR TITLE
chore(workflows): bump version of various GHA workflows

### DIFF
--- a/.github/workflows/build-authors-cache.yml
+++ b/.github/workflows/build-authors-cache.yml
@@ -13,12 +13,12 @@ jobs:
     name: Build Authors Cache
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 20.x
       - name: Cache node_modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache
         with:
           path: node_modules

--- a/.github/workflows/build-pdf-typst.yml
+++ b/.github/workflows/build-pdf-typst.yml
@@ -16,10 +16,10 @@ jobs:
       LANG: C.UTF-8
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20.x
           cache: 'npm'
@@ -52,7 +52,7 @@ jobs:
           cd ..
           cp -r fonts/* .fonts
 
-      - uses: typst-community/setup-typst@v4
+      - uses: typst-community/setup-typst@v5
         with:
           typst-version: 0.13.1
           cache-dependency-path: OI-Wiki-export/oi-wiki-export-typst/oi-wiki.typ
@@ -65,7 +65,7 @@ jobs:
           typst compile oi-wiki-export.typ --font-path .fonts
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: OI-wiki-typst-export
           path: ./OI-Wiki-export/oi-wiki-export-typst/oi-wiki-export.pdf

--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -10,9 +10,9 @@ jobs:
     name: OI-Wiki LaTeX Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build the LaTeX document
-        uses: xu-cheng/latex-action@v3
+        uses: xu-cheng/latex-action@v4
         with:
           latexmk_use_xelatex: true
           latexmk_shell_escape: true
@@ -55,7 +55,7 @@ jobs:
             node index.js ../../
           root_file: |
             oi-wiki-export.tex
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: OI-wiki-latex-export
           path: ./OI-Wiki-export/oi-wiki-export/oi-wiki-export.pdf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,24 +14,24 @@ jobs:
     name: OI-Wiki Page Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "latest"
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20.x'
           check-latest: true
       - name: Install Python dependencies
         run: uv sync
       - name: Cache Node.js dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache-node
         with:
           path: node_modules
@@ -59,7 +59,7 @@ jobs:
         with:
           skip_external: true
       - name: Fetch old site
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: gh-pages
           path: old-site
@@ -86,26 +86,26 @@ jobs:
     if: ${{ github.ref == 'refs/heads/master' }}
     steps:
       - name: Checkout latest
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Get changed files
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@v47
         with:
           files: docs/**/*.md
           include_all_old_new_renamed_files: true
           write_output_files: true
       - name: Checkout before
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.before }}
           path: before
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
             python-version: '3.10'
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "latest"
       - name: Install Python dependencies

--- a/.github/workflows/celebration.yml
+++ b/.github/workflows/celebration.yml
@@ -10,12 +10,12 @@ jobs:
   celebrate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "latest"
       - name: Install Python dependencies

--- a/.github/workflows/check-characters.yml
+++ b/.github/workflows/check-characters.yml
@@ -14,20 +14,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Get Changed Files
         id: changed-files
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@v47
         with:
           files: |
             docs/**/*.md
             docs/**/*.tex
       - name: Setup Python
         if: steps.changed-files.outputs.any_changed == 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Check Changed Files

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20.x'
           check-latest: true
@@ -30,13 +30,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20.x'
           check-latest: true
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Install clang-format-18 and ruff from pypi
@@ -69,7 +69,7 @@ jobs:
           mkdir -p .debug
           git diff > .debug/changed.patch
       - name: Upload patch to artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: changes by bot
           path: .debug/changed.patch

--- a/.github/workflows/check-scripts.yml
+++ b/.github/workflows/check-scripts.yml
@@ -17,13 +17,13 @@ jobs:
     name: Check Node.js Scripts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '20.x'
           check-latest: true
       - name: Cache Node.js dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache-node
         with:
           path: node_modules
@@ -41,12 +41,12 @@ jobs:
     name: Check Python Scripts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "latest"
       - name: Install Python dependencies

--- a/.github/workflows/incrementally-build-pdf.yml
+++ b/.github/workflows/incrementally-build-pdf.yml
@@ -26,9 +26,9 @@ jobs:
     if: needs.pre_build.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build the LaTeX document
-        uses: xu-cheng/latex-action@v3
+        uses: xu-cheng/latex-action@v4
         with:
           latexmk_use_xelatex: true
           latexmk_shell_escape: true
@@ -73,7 +73,7 @@ jobs:
             node incremental-build.js ${{ github.ref }} ${{ secrets.GITHUB_TOKEN }}
           root_file: |
             oi-wiki-export.tex
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: OI-wiki.pdf
           path: ./OI-Wiki-export/oi-wiki-export/oi-wiki-export.pdf

--- a/.github/workflows/lint_pr_title.yml
+++ b/.github/workflows/lint_pr_title.yml
@@ -13,7 +13,7 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v6
         id: lint_pr_title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -37,7 +37,7 @@ jobs:
           ignoreLabels: |
             bot
             ignore-semantic-pull-request
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@v3
         # When the previous steps fails, the workflow would stop. By adding this
         # condition you can continue the execution with the populated error message.
         if: always() && (steps.lint_pr_title.outputs.error_message != null)

--- a/.github/workflows/pr-stale.yml
+++ b/.github/workflows/pr-stale.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Close Stale PR
-        uses: actions/stale@v9
+        uses: actions/stale@v10
         with:
           stale-pr-message: |
             你好 :wave:

--- a/.github/workflows/remove-labels.yml
+++ b/.github/workflows/remove-labels.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v8
+      - uses: actions/github-script@v9
         with:
           script: |
             const labelsRemoved = [

--- a/.github/workflows/suggest-pr-reopen.yml
+++ b/.github/workflows/suggest-pr-reopen.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Post comment
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,24 +16,24 @@ jobs:
       any_changed: ${{ steps.changed-files.outputs.any_changed }}
       files_to_test: ${{ steps.GetFiles.outputs.files_to_test }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Get changed code files
         id: changed-files
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@v47
         with:
           files: |
             docs/**/*.cpp
             docs/**/*.in
             docs/**/*.ans
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         if: steps.changed-files.outputs.any_changed == 'true'
         with:
           python-version: '3.10'
       - name: Install uv
         if: steps.changed-files.outputs.any_changed == 'true'
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "latest"
       - name: Install Python dependencies
@@ -66,7 +66,7 @@ jobs:
     outputs:
       output: ${{ steps.set-output.outputs.output }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install g++-9
@@ -88,7 +88,7 @@ jobs:
     outputs:
       output: ${{ steps.set-output.outputs.output }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Check Compiler Version
@@ -114,7 +114,7 @@ jobs:
     outputs:
       output: ${{ steps.set-output.outputs.output }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Launch Risc-V Docker
@@ -154,7 +154,7 @@ jobs:
     outputs:
       output: ${{ steps.set-output.outputs.output }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Check Compiler Version
@@ -192,7 +192,7 @@ jobs:
       output: ${{ steps.set-output.outputs.output }}
     container: alpine:latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Check Compiler Version


### PR DESCRIPTION
- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

避免出现类似 warning：

```plain
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v4, actions/checkout@v4, actions/setup-node@v4, actions/setup-python@v5, astral-sh/setup-uv@v6, peaceiris/actions-gh-pages@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 若本 Pull Request 能够完全解决某个 Issue，请将该 Pull Request 与对应的 Issue 链接起来，具体做法请参见 <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->
