### PR TITLE
fix(geometry/convex-hull): make minkowski_sum comparator type-generic

### DIFF
--- a/docs/geometry/code/convex-hull/convex-hull_1.cpp
+++ b/docs/geometry/code/convex-hull/convex-hull_1.cpp
@@ -92,7 +92,7 @@ int main() {
     }
     auto it = upper_bound(
         a.begin() + 1, a.end(), v,
-        [](const Point<i64> &a, const Point<i64> &b) { return (a ^ b) < 0; });
+        [](const Point<T> &a, const Point<T> &b) { return (a ^ b) < 0; });
     if (it == a.begin() + 1 || it == a.end()) {
       cout << "0\n";
       continue;

--- a/docs/geometry/code/convex-hull/convex-hull_1.cpp
+++ b/docs/geometry/code/convex-hull/convex-hull_1.cpp
@@ -65,7 +65,7 @@ vector<Point<T>> minkowski_sum(vector<Point<T>> a, vector<Point<T>> b) {
   a.pop_back(), b.pop_back();
   c.resize(a.size() + b.size() + 1);
   merge(a.begin(), a.end(), b.begin(), b.end(), c.begin() + 1,
-        [](const Point<i64> &a, const Point<i64> &b) { return (a ^ b) < 0; });
+        [](const Point<T> &a, const Point<T> &b) { return (a ^ b) < 0; });
   for (usz i = 1; i < c.size(); ++i) c[i] = c[i] + c[i - 1];
   return c;
 }
@@ -92,7 +92,7 @@ int main() {
     }
     auto it = upper_bound(
         a.begin() + 1, a.end(), v,
-        [](const Point<T> &a, const Point<T> &b) { return (a ^ b) < 0; });
+        [](const Point<i64> &a, const Point<i64> &b) { return (a ^ b) < 0; });
     if (it == a.begin() + 1 || it == a.end()) {
       cout << "0\n";
       continue;

--- a/docs/geometry/convex-hull.md
+++ b/docs/geometry/convex-hull.md
@@ -265,7 +265,7 @@ $$
       a.pop_back(), b.pop_back();
       c.resize(a.size() + b.size() + 1);
       merge(a.begin(), a.end(), b.begin(), b.end(), c.begin() + 1,
-            [](const Point<i64> &a, const Point<i64> &b) { return (a ^ b) < 0; });
+            [](const Point<T> &a, const Point<T> &b) { return (a ^ b) < 0; });
       for (usz i = 1; i < c.size(); ++i) c[i] = c[i] + c[i - 1];
       return c;
     }


### PR DESCRIPTION
- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

`minkowski_sum` 这个函数的签名是泛型的，但是函数体里却用了 `Point<i64>`。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 若本 Pull Request 能够完全解决某个 Issue，请将该 Pull Request 与对应的 Issue 链接起来，具体做法请参见 <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->
