### PR TITLE
fix(poly/comp-rev.md): 对部分说法增加注释以及修正一处丢失的阶乘符号

### DIFF
--- a/docs/math/poly/comp-rev.md
+++ b/docs/math/poly/comp-rev.md
@@ -1,4 +1,4 @@
-形式幂级数的复合和复合逆也是常见的形式幂级数操作，对于没有特殊性质的 $f$ 之前我们一直使用的多是 $O\left(n^2\right)$ 的算法来计算 $f(g) \bmod{x^n}$ 其中 $f\in\mathbb{C}\left\lbrack\left\lbrack x\right\rbrack\right\rbrack,g\in x\mathbb{C}\left\lbrack\left\lbrack x\right\rbrack\right\rbrack$，但是因为效率较低应用较少．我们介绍 Kinoshita–Li 的 $O\left(\mathsf{M}\left(n\right)\log n\right)$ 的算法，其中 $O\left(\mathsf{M}\left(n\right)\right)$ 为两个次数为 $O\left( n\right)$ 的多项式相乘的时间．
+形式幂级数的复合和复合逆也是常见的形式幂级数操作，对于没有特殊性质的 $f$ 之前我们一直使用的多是 $O\left(n^2\right)$ 的算法（该算法仍需使用 FFT）来计算 $f(g) \bmod{x^n}$ 其中 $f\in\mathbb{C}\left\lbrack\left\lbrack x\right\rbrack\right\rbrack,g\in x\mathbb{C}\left\lbrack\left\lbrack x\right\rbrack\right\rbrack$，但是因为效率较低应用较少．我们介绍 Kinoshita–Li 的 $O\left(\mathsf{M}\left(n\right)\log n\right)$ 的算法，其中 $O\left(\mathsf{M}\left(n\right)\right)$ 为两个次数为 $O\left( n\right)$ 的多项式相乘的时间．
 
 ## 形式幂级数/多项式的复合
 
@@ -70,7 +70,7 @@ $$
 g(0)=1&,\space g^{-1}=1+(1-g)+(1-g)^2+\cdots \\
 g(0)=1&,\space \log g=-\dfrac{1-g}{1}-\dfrac{(1-g)^2}{2}-\dfrac{(1-g)^3}{3}-\cdots \\
 g(0)=0&,\space \exp g=1+\dfrac{g}{1!}+\dfrac{g^2}{2!}+\dfrac{g^3}{3!}+\cdots \\
-g(0)=1&,\space g^e=1+\dfrac{e}{1}(g-1)+\dfrac{e(e-1)}{2}(g-1)^2+\cdots
+g(0)=1&,\space g^e=1+\dfrac{e}{1!}(g-1)+\dfrac{e(e-1)}{2!}(g-1)^2+\cdots
 \end{aligned}
 $$
 


### PR DESCRIPTION
- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 若本 Pull Request 能够完全解决某个 Issue，请将该 Pull Request 与对应的 Issue 链接起来，具体做法请参见 <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->

如题，之前写公式的时候漏掉了阶乘符号，在代码里面其实是有的

https://github.com/OI-wiki/OI-wiki/blob/b8f4b746cc99f6e1bdc6dabcc9606b554ba5d20e/docs/math/code/poly/comp-rev/rev_1.cpp#L184-L188

对应

$$
\begin{aligned}
g(0) &= 1 \\
g^e  &= 1 + \dfrac{e}{1!}(g-1) + \dfrac{e(e-1)}{2!}(g-1)^2 + \cdots
\end{aligned}
$$

P.S. FPS 复合的近线性算法作者之一 Elegia 在 UOJ 群里说如果可以把二维多项式乘法在 $O(nm \max(n,m))$ 完成的话，使用 Kinoshita–Li 算法就可以在 $O(n^2)$ 完成计算。我尝试理解了一下，还是需要求值和插值，可能要结合 Schönhage–Strassen 算法的一部分思想才能做到。