### PR TITLE
fix(docs/math/number-theory/primitive-root.md): 修改一处推理过程

### DIFF
--- a/docs/math/number-theory/primitive-root.md
+++ b/docs/math/number-theory/primitive-root.md
@@ -510,7 +510,7 @@ Carmichael 函数是一个 [数论函数](./basic.md#数论函数)．本节讨�
     所以，$\delta_m(1+p)=p^{e-1}$．另外，设模 $p$ 的原根为 $g$，那么，由于 $g^{\delta_m(g)}\equiv 1 \pmod{p}$，所以，由阶的 [性质 2](#ord-prop-2) 可知，$p-1\mid\delta_m(g)$．由 Carmichael 函数的定义和欧拉定理可知
     
     $$
-    p^{e-1}(p-1) = [\delta_m(1+p),\delta_m(g)]\mid\lambda(m) \mid \varphi(m) = p^{e-1}(p-1).
+    p^{e-1}(p-1) \mid [\delta_m(1+p),\delta_m(g)] \mid \lambda(m) \mid \varphi(m) = p^{e-1}(p-1).
     $$
     
     因此，$\lambda(m)=p^{e-1}(p-1)$．


### PR DESCRIPTION
Carmichael函数递推公式的第3个引理的证明中，p^{e-1}(p-1)和[\delta_m(1+p), \delta_m(g)]之间的相等关系不能由之前的推理得出，修改为整除关系。

- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 若本 Pull Request 能够完全解决某个 Issue，请将该 Pull Request 与对应的 Issue 链接起来，具体做法请参见 <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->
