### PR TITLE
fix(graph/scc): 修正 Kosaraju 第二次遍历的下标越界

### DIFF
--- a/docs/graph/scc.md
+++ b/docs/graph/scc.md
@@ -200,7 +200,7 @@ Kosaraju 算法最早在 1978 年由 S. Rao Kosaraju 在一篇未发表的论文
       sccCnt = 0;
       for (int i = 1; i <= n; ++i)
         if (!vis[i]) dfs1(i);
-      for (int i = n; i >= 1; --i)
+      for (int i = n - 1; i >= 0; --i)
         if (!color[s[i]]) {
           ++sccCnt;
           dfs2(s[i]);
@@ -230,7 +230,7 @@ Kosaraju 算法最早在 1978 年由 S. Rao Kosaraju 在一篇未发表的论文
         for i in range(1, n + 1):
             if vis[i] == False:
                 dfs1(i)
-        for i in range(n, 0, -1):
+        for i in range(n - 1, -1, -1):
             if color[s[i]] == False:
                 sccCnt = sccCnt + 1
                 dfs2(s[i])


### PR DESCRIPTION
## 问题
  
  `docs/graph/scc.md` 中 Kosaraju 算法的实现里,`s` 通过 `push_back` / `append` 填充,合法下标为 `0 .. n-1`(0-indexed)。但第二次遍历写成了:

  - C++: `for (int i = n; i >= 1; --i)`
  - Python: `for i in range(n, 0, -1)`

  这会访问 `s[n]`(**越界**)并遗漏 `s[0]`(dfs1 中最先入栈的节点),导致越界读取与 SCC 漏算。

  ## 复现

  在最简单的图 `1 -> 2` 上,用 AddressSanitizer 编译运行原实现即触发 heap-buffer-overflow(读 `s[n]`)。

  ## 修复

  将第二次遍历改为遍历合法下标 `n-1 .. 0`:

  - C++: `for (int i = n - 1; i >= 0; --i)`
  - Python: `for i in range(n - 1, -1, -1)`

  C++ 与 Python 两处保持一致。