### PR TITLE
fix(graph/shortest-path.md): 修正 Dijkstra 朴素实现中 Edge 类的 __init__ 拼写错误

### DIFF
--- a/docs/graph/shortest-path.md
+++ b/docs/graph/shortest-path.md
@@ -414,7 +414,7 @@ Dijkstra（/ˈdikstrɑ/或/ˈdɛikstrɑ/）算法由荷兰计算机科学家 E. 
     === "Python"
         ```python
         class Edge:
-            def __init(self, v=0, w=0):
+            def __init__(self, v=0, w=0):
                 self.v = v
                 self.w = w
         


### PR DESCRIPTION
# Fix typo in Edge class constructor method

- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 若本 Pull Request 能够完全解决某个 Issue，请将该 Pull Request 与对应的 Issue 链接起来，具体做法请参见 <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->

## 修复内容

在 `docs/graph/shortest-path.md` 第 417 行的 Dijkstra 朴素实现 Python 代码中，`Edge` 类的构造函数误写为：

```python
def __init(self, v=0, w=0):
```

缺少了末尾的第二个下划线，导致 Python 无法将其识别为魔法方法 __init__，实例化 Edge() 时不会自动调用该方法，self.v 和 self.w 未被赋值，后续代码访问 ed.v / ed.w 时会抛出 AttributeError。

本次修改将其更正为：

```python
def __init__(self, v=0, w=0):
```