### PR TITLE
feat(math/probability/concentration-inequality.md): 增加了 Cherloff 与 Hoeffding 不等式与中心极限定理的关系

### DIFF
--- a/docs/math/probability/concentration-inequality.md
+++ b/docs/math/probability/concentration-inequality.md
@@ -123,37 +123,37 @@ $$
 
 Chernoff 不等式和 Hoeffding 不等式都限制了随机变量偏离其期望值的程度．这两个不等式的证明过程较为冗长，有兴趣的同学可以查阅 Probability and Computing 一书中的相关章节．
 
-??? note "与中心极限定理的关系"   
-   Chernoff 不等式和 Hoeffding 不等式都是中心极限定理在有限大小的 $n$ 下的保守估计.   
-   对于 Possion 实验之和的 Chernoff 不等式，有
+??? note "与中心极限定理的关系"
+    
 
-   $$
-   \lim_{n\rightarrow\infty} P\{|X-EX|\ge \epsilon\sqrt{DX}\}=1-\int_{-\epsilon}^{\epsilon}\dfrac{\mathrm{e}^{-\frac{t^2}{2} } }{\sqrt{2\pi} }\mathrm{d}t\le2\mathrm{e}^{-\frac{\epsilon^2}{3} }\le\mathop{\underline{\lim} }\limits_{n\rightarrow\infty}2\exp\left(-\dfrac{1}{3}\mu\left(\dfrac{\epsilon\sqrt{DX} }{\mu}\right)^2\right)
-   $$
+Chernoff 不等式和 Hoeffding 不等式都是中心极限定理在有限大小的 $n$ 下的保守估计．  
+对于 Possion 实验之和的 Chernoff 不等式，有
 
-   对于 Hoeffding 不等式，注意到
+$$
+\lim_{n\rightarrow\infty} P\{|X-EX|\ge \epsilon\sqrt{DX}\}=1-\int_{-\epsilon}^{\epsilon}\dfrac{\mathrm{e}^{-\frac{t^2}{2} } }{\sqrt{2\pi} }\mathrm{d}t\le2\mathrm{e}^{-\frac{\epsilon^2}{3} }\le\mathop{\underline{\lim} }\limits_{n\rightarrow\infty}2\exp\left(-\dfrac{1}{3}\mu\left(\dfrac{\epsilon\sqrt{DX} }{\mu}\right)^2\right)
+$$
 
-   $$
-   DX_i\le\dfrac{(b_i-a_i)^2}{4}
-   $$
+对于 Hoeffding 不等式，注意到
 
-   当且仅当 $P\{X_i=a_i\}=P\{X_i=b_i\}=\dfrac{1}{2}$ 时取等号，故
-   
-   $$
-   2\exp\left(\dfrac{-2\epsilon^2 D X}{\sum\limits_{i=1}^n(b_i-a_i)^2}\right)\ge 2\mathrm{e}^{-\frac{\epsilon^2}{2} }
-   $$
+$$
+DX_i\le\dfrac{(b_i-a_i)^2}{4}
+$$
 
-   于是
-   
-   $$
-   \lim_{n\rightarrow\infty}P\{|X-EX|\ge \epsilon\sqrt{DX}\}=1-\int_{-\epsilon}^{\epsilon}\dfrac{\mathrm{e}^{-\frac{t^2}{2} } }{\sqrt{2\pi} }\mathrm{d}t\le2\mathrm{e}^{-\frac{\epsilon^2}{2} }\le \mathop{\underline{\lim}}\limits_{n\rightarrow\infty}2\exp\left(\dfrac{-2\epsilon^2 D X}{\sum\limits_{i=1}^n(b_i-a_i)^2}\right)
-   $$
-   
-   在实践中，往往先通过中心极限定理辅助判断 $X$ 大致的概率分布，再使用相对宽松但更严格的 Chernoff 不等式或 Hoeffding 不等式进行证明.
+当且仅当 $P\{X_i=a_i\}=P\{X_i=b_i\}=\dfrac{1}{2}$ 时取等号，故
 
+$$
+2\exp\left(\dfrac{-2\epsilon^2 D X}{\sum\limits_{i=1}^n(b_i-a_i)^2}\right)\ge 2\mathrm{e}^{-\frac{\epsilon^2}{2} }
+$$
+
+于是
+
+$$
+\lim_{n\rightarrow\infty}P\{|X-EX|\ge \epsilon\sqrt{DX}\}=1-\int_{-\epsilon}^{\epsilon}\dfrac{\mathrm{e}^{-\frac{t^2}{2} } }{\sqrt{2\pi} }\mathrm{d}t\le2\mathrm{e}^{-\frac{\epsilon^2}{2} }\le \mathop{\underline{\lim}}\limits_{n\rightarrow\infty}2\exp\left(\dfrac{-2\epsilon^2 D X}{\sum\limits_{i=1}^n(b_i-a_i)^2}\right)
+$$
+
+在实践中，往往先通过中心极限定理辅助判断 $X$ 大致的概率分布，再使用相对宽松但更严格的 Chernoff 不等式或 Hoeffding 不等式进行证明．
 
 从经验上讲，如果 $EX$ 不太接近 $a_1+\cdots+a_n$，则该不等式给出的界往往相对比较紧；如果非常接近的话（例如在 [UOJ #72 全新做法](https://matthew99.blog.uoj.ac/blog/5511) 中），给出的界则往往很松，此时更好的选择是使用 Chernoff 不等式．
-
 
 ## 应用举例
 

--- a/docs/math/probability/concentration-inequality.md
+++ b/docs/math/probability/concentration-inequality.md
@@ -149,7 +149,7 @@ Chernoff 不等式和 Hoeffding 不等式都限制了随机变量偏离其期望
    \lim_{n\rightarrow\infty}P\{|X-EX|\ge \epsilon\sqrt{DX}\}=1-\int_{-\epsilon}^{\epsilon}\dfrac{\mathrm{e}^{-\frac{t^2}{2} } }{\sqrt{2\pi} }\mathrm{d}t\le2\mathrm{e}^{-\frac{\epsilon^2}{2} }\le \mathop{\underline{\lim}}\limits_{n\rightarrow\infty}2\exp\left(\dfrac{-2\epsilon^2 D X}{\sum\limits_{i=1}^n(b_i-a_i)^2}\right)
    $$
    
-   在实践中，往往先根据中心极限定理辅助判断 $X$ 大致的概率分布，再使用相对宽松但更严格的 Cherloff 不等式或 Hoeffding 不等式进行证明。
+   在实践中，往往先根据中心极限定理辅助判断 $X$ 大致的概率分布，再使用相对宽松但更严格的 Cherloff 不等式或 Hoeffding 不等式进行证明.
 
 
 从经验上讲，如果 $EX$ 不太接近 $a_1+\cdots+a_n$，则该不等式给出的界往往相对比较紧；如果非常接近的话（例如在 [UOJ #72 全新做法](https://matthew99.blog.uoj.ac/blog/5511) 中），给出的界则往往很松，此时更好的选择是使用 Chernoff 不等式．

--- a/docs/math/probability/concentration-inequality.md
+++ b/docs/math/probability/concentration-inequality.md
@@ -124,34 +124,32 @@ $$
 Chernoff 不等式和 Hoeffding 不等式都限制了随机变量偏离其期望值的程度．这两个不等式的证明过程较为冗长，有兴趣的同学可以查阅 Probability and Computing 一书中的相关章节．
 
 ??? note "与中心极限定理的关系"
+    Chernoff 不等式和 Hoeffding 不等式都是中心极限定理在有限大小的 $n$ 下的保守估计．  
+    对于 Possion 实验之和的 Chernoff 不等式，有
     
-
-Chernoff 不等式和 Hoeffding 不等式都是中心极限定理在有限大小的 $n$ 下的保守估计．  
-对于 Possion 实验之和的 Chernoff 不等式，有
-
-$$
-\lim_{n\rightarrow\infty} P\{|X-EX|\ge \epsilon\sqrt{DX}\}=1-\int_{-\epsilon}^{\epsilon}\dfrac{\mathrm{e}^{-\frac{t^2}{2} } }{\sqrt{2\pi} }\mathrm{d}t\le2\mathrm{e}^{-\frac{\epsilon^2}{3} }\le\mathop{\underline{\lim} }\limits_{n\rightarrow\infty}2\exp\left(-\dfrac{1}{3}\mu\left(\dfrac{\epsilon\sqrt{DX} }{\mu}\right)^2\right)
-$$
-
-对于 Hoeffding 不等式，注意到
-
-$$
-DX_i\le\dfrac{(b_i-a_i)^2}{4}
-$$
-
-当且仅当 $P\{X_i=a_i\}=P\{X_i=b_i\}=\dfrac{1}{2}$ 时取等号，故
-
-$$
-2\exp\left(\dfrac{-2\epsilon^2 D X}{\sum\limits_{i=1}^n(b_i-a_i)^2}\right)\ge 2\mathrm{e}^{-\frac{\epsilon^2}{2} }
-$$
-
-于是
-
-$$
-\lim_{n\rightarrow\infty}P\{|X-EX|\ge \epsilon\sqrt{DX}\}=1-\int_{-\epsilon}^{\epsilon}\dfrac{\mathrm{e}^{-\frac{t^2}{2} } }{\sqrt{2\pi} }\mathrm{d}t\le2\mathrm{e}^{-\frac{\epsilon^2}{2} }\le \mathop{\underline{\lim}}\limits_{n\rightarrow\infty}2\exp\left(\dfrac{-2\epsilon^2 D X}{\sum\limits_{i=1}^n(b_i-a_i)^2}\right)
-$$
-
-在实践中，往往先通过中心极限定理辅助判断 $X$ 大致的概率分布，再使用相对宽松但更严格的 Chernoff 不等式或 Hoeffding 不等式进行证明．
+    $$
+    \lim_{n\rightarrow\infty} P\{|X-EX|\ge \epsilon\sqrt{DX}\}=1-\int_{-\epsilon}^{\epsilon}\dfrac{\mathrm{e}^{-\frac{t^2}{2} } }{\sqrt{2\pi} }\mathrm{d}t\le2\mathrm{e}^{-\frac{\epsilon^2}{3} }\le\mathop{\underline{\lim} }\limits_{n\rightarrow\infty}2\exp\left(-\dfrac{1}{3}\mu\left(\dfrac{\epsilon\sqrt{DX} }{\mu}\right)^2\right)
+    $$
+    
+    对于 Hoeffding 不等式，注意到
+    
+    $$
+    DX_i\le\dfrac{(b_i-a_i)^2}{4}
+    $$
+    
+    当且仅当 $P\{X_i=a_i\}=P\{X_i=b_i\}=\dfrac{1}{2}$ 时取等号，故
+    
+    $$
+    2\exp\left(\dfrac{-2\epsilon^2 D X}{\sum\limits_{i=1}^n(b_i-a_i)^2}\right)\ge 2\mathrm{e}^{-\frac{\epsilon^2}{2} }
+    $$
+    
+    于是
+    
+    $$
+    \lim_{n\rightarrow\infty}P\{|X-EX|\ge \epsilon\sqrt{DX}\}=1-\int_{-\epsilon}^{\epsilon}\dfrac{\mathrm{e}^{-\frac{t^2}{2} } }{\sqrt{2\pi} }\mathrm{d}t\le2\mathrm{e}^{-\frac{\epsilon^2}{2} }\le \mathop{\underline{\lim}}\limits_{n\rightarrow\infty}2\exp\left(\dfrac{-2\epsilon^2 D X}{\sum\limits_{i=1}^n(b_i-a_i)^2}\right)
+    $$
+    
+    在实践中，往往先通过中心极限定理辅助判断 $X$ 大致的概率分布，再使用相对宽松但更严格的 Chernoff 不等式或 Hoeffding 不等式进行证明．
 
 从经验上讲，如果 $EX$ 不太接近 $a_1+\cdots+a_n$，则该不等式给出的界往往相对比较紧；如果非常接近的话（例如在 [UOJ #72 全新做法](https://matthew99.blog.uoj.ac/blog/5511) 中），给出的界则往往很松，此时更好的选择是使用 Chernoff 不等式．
 

--- a/docs/math/probability/concentration-inequality.md
+++ b/docs/math/probability/concentration-inequality.md
@@ -123,7 +123,37 @@ $$
 
 Chernoff 不等式和 Hoeffding 不等式都限制了随机变量偏离其期望值的程度．这两个不等式的证明过程较为冗长，有兴趣的同学可以查阅 Probability and Computing 一书中的相关章节．
 
+??? note "与中心极限定理的关系"   
+   Chernoff 不等式和 Hoeffding 不等式都是中心极限定理在有限大小的 $n$ 下的保守估计.   
+   对于 Possion 实验之和的 Cherloff 不等式，有
+
+   $$
+   \lim_{n\rightarrow\infty} P\{|X-EX|\ge \epsilon\sqrt{DX}\}=1-\int_{-\epsilon}^{\epsilon}\dfrac{\mathrm{e}^{-\frac{t^2}{2} } }{\sqrt{2\pi} }\mathrm{d}t\le2\mathrm{e}^{-\frac{\epsilon^2}{3} }\le\mathop{\underline{\lim} }\limits_{n\rightarrow\infty}2\exp\left(-\dfrac{1}{3}\mu\left(\dfrac{\epsilon\sqrt{DX} }{\mu}\right)^2\right)
+   $$
+
+   对于 Hoeffding 不等式，注意到
+
+   $$
+   DX_i\le\dfrac{(b_i-a_i)^2}{4}
+   $$
+
+   当且仅当 $P\{X_i=a_i\}=P\{X_i=b_i\}=\dfrac{1}{2}$ 时取等号，故
+   
+   $$
+   2\exp\left(\dfrac{-2\epsilon^2 D X}{\sum\limits_{i=1}^n(b_i-a_i)^2}\right)\ge 2\mathrm{e}^{-\frac{\epsilon^2}{2} }
+   $$
+
+   于是
+   
+   $$
+   \lim_{n\rightarrow\infty}P\{|X-EX|\ge \epsilon\sqrt{DX}\}=1-\int_{-\epsilon}^{\epsilon}\dfrac{\mathrm{e}^{-\frac{t^2}{2} } }{\sqrt{2\pi} }\mathrm{d}t\le2\mathrm{e}^{-\frac{\epsilon^2}{2} }\le \mathop{\underline{\lim}}\limits_{n\rightarrow\infty}2\exp\left(\dfrac{-2\epsilon^2 D X}{\sum\limits_{i=1}^n(b_i-a_i)^2}\right)
+   $$
+   
+   在实践中，往往先根据中心极限定理辅助判断 $X$ 大致的概率分布，再使用相对宽松但更严格的 Cherloff 不等式或 Hoeffding 不等式进行证明。
+
+
 从经验上讲，如果 $EX$ 不太接近 $a_1+\cdots+a_n$，则该不等式给出的界往往相对比较紧；如果非常接近的话（例如在 [UOJ #72 全新做法](https://matthew99.blog.uoj.ac/blog/5511) 中），给出的界则往往很松，此时更好的选择是使用 Chernoff 不等式．
+
 
 ## 应用举例
 

--- a/docs/math/probability/concentration-inequality.md
+++ b/docs/math/probability/concentration-inequality.md
@@ -149,7 +149,7 @@ Chernoff 不等式和 Hoeffding 不等式都限制了随机变量偏离其期望
    \lim_{n\rightarrow\infty}P\{|X-EX|\ge \epsilon\sqrt{DX}\}=1-\int_{-\epsilon}^{\epsilon}\dfrac{\mathrm{e}^{-\frac{t^2}{2} } }{\sqrt{2\pi} }\mathrm{d}t\le2\mathrm{e}^{-\frac{\epsilon^2}{2} }\le \mathop{\underline{\lim}}\limits_{n\rightarrow\infty}2\exp\left(\dfrac{-2\epsilon^2 D X}{\sum\limits_{i=1}^n(b_i-a_i)^2}\right)
    $$
    
-   在实践中，往往先根据中心极限定理辅助判断 $X$ 大致的概率分布，再使用相对宽松但更严格的 Cherloff 不等式或 Hoeffding 不等式进行证明.
+   在实践中，往往先通过中心极限定理辅助判断 $X$ 大致的概率分布，再使用相对宽松但更严格的 Cherloff 不等式或 Hoeffding 不等式进行证明.
 
 
 从经验上讲，如果 $EX$ 不太接近 $a_1+\cdots+a_n$，则该不等式给出的界往往相对比较紧；如果非常接近的话（例如在 [UOJ #72 全新做法](https://matthew99.blog.uoj.ac/blog/5511) 中），给出的界则往往很松，此时更好的选择是使用 Chernoff 不等式．

--- a/docs/math/probability/concentration-inequality.md
+++ b/docs/math/probability/concentration-inequality.md
@@ -125,7 +125,7 @@ Chernoff 不等式和 Hoeffding 不等式都限制了随机变量偏离其期望
 
 ??? note "与中心极限定理的关系"   
    Chernoff 不等式和 Hoeffding 不等式都是中心极限定理在有限大小的 $n$ 下的保守估计.   
-   对于 Possion 实验之和的 Cherloff 不等式，有
+   对于 Possion 实验之和的 Chernoff 不等式，有
 
    $$
    \lim_{n\rightarrow\infty} P\{|X-EX|\ge \epsilon\sqrt{DX}\}=1-\int_{-\epsilon}^{\epsilon}\dfrac{\mathrm{e}^{-\frac{t^2}{2} } }{\sqrt{2\pi} }\mathrm{d}t\le2\mathrm{e}^{-\frac{\epsilon^2}{3} }\le\mathop{\underline{\lim} }\limits_{n\rightarrow\infty}2\exp\left(-\dfrac{1}{3}\mu\left(\dfrac{\epsilon\sqrt{DX} }{\mu}\right)^2\right)
@@ -149,7 +149,7 @@ Chernoff 不等式和 Hoeffding 不等式都限制了随机变量偏离其期望
    \lim_{n\rightarrow\infty}P\{|X-EX|\ge \epsilon\sqrt{DX}\}=1-\int_{-\epsilon}^{\epsilon}\dfrac{\mathrm{e}^{-\frac{t^2}{2} } }{\sqrt{2\pi} }\mathrm{d}t\le2\mathrm{e}^{-\frac{\epsilon^2}{2} }\le \mathop{\underline{\lim}}\limits_{n\rightarrow\infty}2\exp\left(\dfrac{-2\epsilon^2 D X}{\sum\limits_{i=1}^n(b_i-a_i)^2}\right)
    $$
    
-   在实践中，往往先通过中心极限定理辅助判断 $X$ 大致的概率分布，再使用相对宽松但更严格的 Cherloff 不等式或 Hoeffding 不等式进行证明.
+   在实践中，往往先通过中心极限定理辅助判断 $X$ 大致的概率分布，再使用相对宽松但更严格的 Chernoff 不等式或 Hoeffding 不等式进行证明.
 
 
 从经验上讲，如果 $EX$ 不太接近 $a_1+\cdots+a_n$，则该不等式给出的界往往相对比较紧；如果非常接近的话（例如在 [UOJ #72 全新做法](https://matthew99.blog.uoj.ac/blog/5511) 中），给出的界则往往很松，此时更好的选择是使用 Chernoff 不等式．


### PR DESCRIPTION
增加公式说明 Cherloff 与 Hoeffding 不等式都是中心极限定理为保证对任意可能分布和 n 一致成立时的保守估计，并说明，中心极限定理虽不常用于严格证明，但可以用于辅助判断概率分布的大致形状

- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 若本 Pull Request 能够完全解决某个 Issue，请将该 Pull Request 与对应的 Issue 链接起来，具体做法请参见 <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->
