### PR TITLE
fix(*): 修正 author 字段的空格与空行

### DIFF
--- a/docs/ds/top-tree.md
+++ b/docs/ds/top-tree.md
@@ -1,4 +1,4 @@
-author:F7487
+author: F7487
 
 ## Self-Adjusting Top Tree
 

--- a/docs/graph/lca.md
+++ b/docs/graph/lca.md
@@ -1,4 +1,4 @@
-author:ouuan, Backl1ght, billchenchina, CCXXXI, ChickenHu, ChungZH, cjsoft, countercurrent-time, diauweb, Early0v0, Enter-tainer, EtaoinWu, H-J-Granger, H-Shen, Henry-ZHR, HeRaNO, hsfzLZH1, huaruoji, iamtwz, imp2002, Ir1d, kenlig, Konano, Lyccrius, Marcythm, Menci, NachtgeistW, PeterlitsZo, psz2007, shuzhouliu, SkqLiao, sshwy, SukkaW, therehello, TrisolarisHD, ttzztztz, vincent-163, WAAutoMaton, Hunter19019
+author: ouuan, Backl1ght, billchenchina, CCXXXI, ChickenHu, ChungZH, cjsoft, countercurrent-time, diauweb, Early0v0, Enter-tainer, EtaoinWu, H-J-Granger, H-Shen, Henry-ZHR, HeRaNO, hsfzLZH1, huaruoji, iamtwz, imp2002, Ir1d, kenlig, Konano, Lyccrius, Marcythm, Menci, NachtgeistW, PeterlitsZo, psz2007, shuzhouliu, SkqLiao, sshwy, SukkaW, therehello, TrisolarisHD, ttzztztz, vincent-163, WAAutoMaton, Hunter19019
 
 ## 定义
 

--- a/docs/graph/save.md
+++ b/docs/graph/save.md
@@ -1,4 +1,5 @@
 author: Ir1d, sshwy, Xeonacid, partychicken, Anguei, HeRaNO
+
 在 OI 中，想要对图进行操作，就需要先学习图的存储方式．
 
 ## 约定

--- a/docs/lang/class.md
+++ b/docs/lang/class.md
@@ -1,4 +1,5 @@
 author: Ir1d, cjsoft, Lans1ot, JasonkayZK
+
 类（class）是结构体的拓展，不仅能够拥有成员元素，还拥有成员函数．
 
 在面向对象编程（OOP）中，对象就是类的实例，也就是变量．


### PR DESCRIPTION
修正了 author 字段的格式，这些格式问题影响了纸质版的渲染。

- ds/top-tree.md、graph/lca.md：author 冒号后缺少空格
- graph/save.md、lang/class.md：author 行后缺少空行

- [x] 我已认真阅读贡献指南 (contributing guidelines) 和社区公约 (code of conduct)，并遵循了如何参与页及格式手册页的相应规范。

<!--
这是 Pull Request 的描述页面，可拖动输入框右下角调节大小。尽管按下绿色按钮提交后，您仍可以对描述进行修改，但还请您先阅读以下注意事项。
- 请不要删去本区域文字，或在此修改内容，因为本区域作为注释内容是不可见的。你应该点击 Preview 查看描述页效果。
- 请勾选输入框外的 `Allow edits from maintainers` 的候选框（机器人需要修正格式），并通过蓝色高亮链接阅读、理解了指南和公约后，将上述 [ ] 替换为 [x]。
- 若本 Pull Request 能够完全解决某个 Issue，请将该 Pull Request 与对应的 Issue 链接起来，具体做法请参见 <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>。
- 请对照规范页面，检查 Commit 信息、PR 标题和下方 Compare 页面，例如：
  - 标题应类似于 `feat(lang/lambda.md): 增加使用对象描述` 。
  - 您的修改是否波及到了其他文件，是否发生了意图之外的文件名修改（这在您启用了翻译软件的情况下较为常见），是否引入了无关文件。
-->
